### PR TITLE
Auto-create signal references

### DIFF
--- a/py2hwsw/scripts/iob_base.py
+++ b/py2hwsw/scripts/iob_base.py
@@ -81,16 +81,17 @@ class iob_attribute_properties:
 #
 
 
-def find_obj_in_list(obj_list, obj_name):
+def find_obj_in_list(obj_list, obj_name, process_func=lambda o: o):
     """Returns an object with a given name from a list of objects
     param obj_list: list of objects (or dictionaries) to search
     param obj_name: name of the object to find
+    param process_func: optional function to apply to each object
     """
     # Support dictionaries as well
     if obj_list and isinstance(obj_list[0], dict):
-        return next((o for o in obj_list if o["name"] == obj_name), None)
+        return next((o for o in obj_list if process_func(o)["name"] == obj_name), None)
 
-    return next((o for o in obj_list if o.name == obj_name), None)
+    return next((o for o in obj_list if process_func(o).name == obj_name), None)
 
 
 def convert_dict2obj_list(dict_list: dict, obj_class):

--- a/py2hwsw/scripts/iob_wire.py
+++ b/py2hwsw/scripts/iob_wire.py
@@ -56,6 +56,8 @@ def create_wire(core, *args, signals=[], **kwargs):
     """
     # Ensure 'wires' list exists
     core.set_default_attribute("wires", [])
+    # Check if there are any references to signals in other wires/ports
+    replace_duplicate_signals_by_references(core.wires + core.ports, signals)
     # Convert user signal dictionaries into 'iob_signal' objects
     sig_obj_list = convert_dict2obj_list(signals, iob_signal)
     wire = iob_wire(*args, signals=sig_obj_list, **kwargs)
@@ -74,7 +76,7 @@ def get_wire_signal(core, wire_name: str, signal_name: str):
     if not wire:
         fail_with_msg(f"Could not find wire/port '{wire_name}'!")
 
-    signal = find_obj_in_list(wire.signals, signal_name)
+    signal = find_obj_in_list(wire.signals, signal_name, process_func=get_real_signal)
     if not signal:
         fail_with_msg(
             f"Could not find signal '{signal_name}' of wire/port '{wire_name}'!"
@@ -90,3 +92,38 @@ def get_real_signal(signal):
     while isinstance(signal, iob_signal_reference):
         signal = signal.signal
     return signal
+
+
+def replace_duplicate_signals_by_references(wires, signals):
+    """Ensure that given list of 'signals' does not contain duplicates of other signals
+    in the given 'wires' list, by replacing the duplicates with references to the
+    original.
+    param wires: list of wires with (original) signals
+    param signals: list of new signals to be processed. If this list has a signal with
+    the same name as another signal in the wires list, then this signal is replaced by a
+    reference to the original.
+    """
+    for idx, signal in enumerate(signals):
+        original_signal = find_signal_in_wires(wires, signal["name"])
+        if not original_signal:
+            continue
+        # print(f"[DEBUG] Replacing signal '{signal['name']}' by reference to original.")
+        # Verify that new signal has same parameters as the original_signal
+        for key, value in signal.items():
+            if original_signal.__dict__[key] != value:
+                fail_with_msg(
+                    f"Signal '{signal['name']}' has different '{key}' than the original signal!"
+                )
+        # Replace signal by a reference to the original
+        signals[idx] = iob_signal_reference(signal=original_signal)
+
+
+def find_signal_in_wires(wires, signal_name):
+    """Search for a signal in given list of wires"""
+    for wire in wires:
+        signal = find_obj_in_list(
+            wire.signals, signal_name, process_func=get_real_signal
+        )
+        if signal:
+            return signal
+    return None


### PR DESCRIPTION
This PR modifies the `create_wire()` method to automatically create signal references if more than one signal have the same name. 
For example, if multiple wires/ports have a signal with the same name, then, one of them will be the original signal and the others will be references to it.

Also fixed handling of `signal` lists by the `find_obj_in_list()` function.