### PR TITLE
Registers can be implicitly declared by using a sufix in the "verilog_code"

### DIFF
--- a/examples/iob_int_sqrt/iob_int_sqrt.py
+++ b/examples/iob_int_sqrt/iob_int_sqrt.py
@@ -1,0 +1,197 @@
+def setup(py_params_dict):
+    attributes_dict = {
+        "original_name": "iob_int_sqrt",
+        "name": "iob_int_sqrt",
+        "version": "0.1",
+        "confs": [
+            {
+                "name": "DATA_W",
+                "type": "P",
+                "val": "32",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Data bus width",
+            },
+            {
+                "name": "FRACTIONAL_W",
+                "type": "P",
+                "val": 0,
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+            {
+                "name": "REAL_W",
+                "type": "P",
+                "val": "DATA_W - FRACTIONAL_W",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+            {
+                "name": "SIZE_W",
+                "type": "P",
+                "val": "(REAL_W / 2) + FRACTIONAL_W",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+            {
+                "name": "END_COUNT",
+                "type": "F",
+                "val": "(DATA_W + FRACTIONAL_W) >> 1",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+            {
+                "name": "COUNT_W",
+                "type": "F",
+                "val": "$clog2(END_COUNT)",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+        ],
+        "ports": [
+            {
+                "name": "start_i",
+                "descr": "Input port",
+                "signals": [
+                    {
+                        "name": "start",
+                        "width": 1,
+                        "direction": "input",
+                    },
+                ],
+            },
+            {
+                "name": "op_i",
+                "descr": "Input port",
+                "signals": [
+                    {
+                        "name": "op",
+                        "width": "DATA_W",
+                        "direction": "input",
+                    },
+                ],
+            },
+            {
+                "name": "done_o",
+                "descr": "Output port",
+                "signals": [
+                    {
+                        "name": "done",
+                        "width": 1,
+                        "direction": "output",
+                    },
+                ],
+            },
+            {
+                "name": "res_o",
+                "descr": "Output port",
+                "signals": [
+                    {
+                        "name": "res",
+                        "width": "SIZE_W",
+                        "direction": "output",
+                    },
+                ],
+            },
+        ],
+        "wires": [
+            {
+                "name": "right",
+                "descr": "right wire",
+                "signals": [
+                    {"name": "right", "width": "SIZE_W+2"},
+                ],
+            },
+            {
+                "name": "left",
+                "descr": "left wire",
+                "signals": [
+                    {"name": "left", "width": "SIZE_W+2"},
+                ],
+            },
+            {
+                "name": "a_in",
+                "descr": "a_in wire",
+                "signals": [
+                    {"name": "a_in", "width": "DATA_W"},
+                ],
+            },
+            {
+                "name": "tmp",
+                "descr": "tmp wire",
+                "signals": [
+                    {"name": "tmp", "width": "SIZE_W+2"},
+                ],
+            },
+            {
+                "name": "q",
+                "descr": "q wire",
+                "signals": [
+                    {"name": "q", "width": "SIZE_W"},
+                ],
+            },
+            {
+                "name": "counter",
+                "descr": "counter wire",
+                "signals": [
+                    {"name": "counter", "width": "COUNT_W"},
+                ],
+            },
+            {
+                "name": "a",
+                "descr": "a wire",
+                "signals": [
+                    {"name": "a", "width": "DATA_W"},
+                ],
+            },
+            {
+                "name": "r",
+                "descr": "r wire",
+                "signals": [
+                    {"name": "r", "width": "SIZE_W+2"},
+                ],
+            },
+        ],
+        "snippets": [
+            {
+                "verilog_code": """
+        assign right = {q, r[SIZE_W+1], 1'b1};
+        assign left = {r[SIZE_W-1:0], a[DATA_W-1 -: 2]};
+        assign a_in = {a[DATA_W-3:0], 2'b00};
+        assign tmp =  r[SIZE_W+1] ? left + right : left - right;
+        assign res_o = q;
+        assign done_o = ~pc0;
+""",
+            },
+        ],
+        "fsms": [
+            {
+                "verilog_code": """
+        idle:
+            if (start_i) begin
+                a_nxt = op_i;
+                q_nxt = 0;
+                r_nxt = 0;
+                counter_nxt = 0;
+            end else begin
+                pc_nxt = pc;
+            end
+
+            r_nxt = tmp;
+            q_nxt = {q[SIZE_W-2:0], ~tmp[SIZE_W+1]};
+            a_nxt = a_in;
+            if (counter != END_COUNT[COUNT_W-1:0] - 1) begin
+                counter_nxt = counter + 1'b1;
+                pc_nxt = pc;
+            end else begin
+                pc_nxt = idle; end
+""",
+            }
+        ],
+    }
+    return attributes_dict

--- a/examples/iob_int_sqrt/iob_int_sqrt_snippet.py
+++ b/examples/iob_int_sqrt/iob_int_sqrt_snippet.py
@@ -1,0 +1,225 @@
+def setup(py_params_dict):
+    attributes_dict = {
+        "original_name": "iob_int_sqrt",
+        "name": "iob_int_sqrt",
+        "version": "0.1",
+        "confs": [
+            {
+                "name": "DATA_W",
+                "type": "P",
+                "val": "32",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Data bus width",
+            },
+            {
+                "name": "FRACTIONAL_W",
+                "type": "P",
+                "val": 0,
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+            {
+                "name": "REAL_W",
+                "type": "P",
+                "val": "DATA_W - FRACTIONAL_W",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+            {
+                "name": "SIZE_W",
+                "type": "P",
+                "val": "(REAL_W / 2) + FRACTIONAL_W",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+            {
+                "name": "END_COUNT",
+                "type": "F",
+                "val": "(DATA_W + FRACTIONAL_W) >> 1",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+            {
+                "name": "COUNT_W",
+                "type": "F",
+                "val": "$clog2(END_COUNT)",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+        ],
+        "ports": [
+            {
+                "name": "clk_rst",
+                "interface": {
+                    "type": "clk_rst",
+                    "subtype": "slave",
+                },
+                "descr": "Clock and reset",
+            },
+            {
+                "name": "start_i",
+                "descr": "Input port",
+                "signals": [
+                    {
+                        "name": "start",
+                        "width": 1,
+                        "direction": "input",
+                    },
+                ],
+            },
+            {
+                "name": "op_i",
+                "descr": "Input port",
+                "signals": [
+                    {
+                        "name": "op",
+                        "width": "DATA_W",
+                        "direction": "input",
+                    },
+                ],
+            },
+            {
+                "name": "done_o",
+                "descr": "Output port",
+                "signals": [
+                    {
+                        "name": "done",
+                        "width": 1,
+                        "direction": "output",
+                    },
+                ],
+            },
+            {
+                "name": "res_o",
+                "descr": "Output port",
+                "signals": [
+                    {
+                        "name": "res",
+                        "width": "SIZE_W",
+                        "direction": "output",
+                    },
+                ],
+            },
+        ],
+        "wires": [
+            {
+                "name": "right",
+                "descr": "right wire",
+                "signals": [
+                    {"name": "right", "width": "SIZE_W+2"},
+                ],
+            },
+            {
+                "name": "left",
+                "descr": "left wire",
+                "signals": [
+                    {"name": "left", "width": "SIZE_W+2"},
+                ],
+            },
+            {
+                "name": "a_in",
+                "descr": "a_in wire",
+                "signals": [
+                    {"name": "a_in", "width": "DATA_W"},
+                ],
+            },
+            {
+                "name": "tmp",
+                "descr": "tmp wire",
+                "signals": [
+                    {"name": "tmp", "width": "SIZE_W+2"},
+                ],
+            },
+            {
+                "name": "q",
+                "descr": "q wire",
+                "signals": [
+                    {"name": "q", "width": "SIZE_W"},
+                ],
+            },
+            {
+                "name": "counter",
+                "descr": "counter wire",
+                "signals": [
+                    {"name": "counter", "width": "COUNT_W"},
+                ],
+            },
+            {
+                "name": "pc",
+                "descr": "pc wire",
+                "signals": [
+                    {"name": "pc", "width": 1},
+                ],
+            },
+            {
+                "name": "a",
+                "descr": "a wire",
+                "signals": [
+                    {"name": "a", "width": "DATA_W"},
+                ],
+            },
+            {
+                "name": "r",
+                "descr": "r wire",
+                "signals": [
+                    {"name": "r", "width": "SIZE_W+2"},
+                ],
+            },
+        ],
+        "snippets": [
+            {
+                "verilog_code": """
+        assign right = {q, r[SIZE_W+1], 1'b1};
+        assign left = {r[SIZE_W-1:0], a[DATA_W-1 -: 2]};
+        assign a_in = {a[DATA_W-3:0], 2'b00};
+        assign tmp =  r[SIZE_W+1]? left + right:left - right;
+        always @(posedge clk_i) begin
+      if (arst_i) begin
+         pc <= 1'd0;
+      end else begin
+         pc <= pc + 1'b1;
+
+         case (pc)
+           0: begin
+              if (start_i) begin
+                 a <= op_i;
+                 q <= 0;
+                 r <= 0;
+
+                 counter <= 0;
+              end else begin
+                 pc <= pc;
+              end
+           end
+           1: begin
+              r <= tmp;
+              q <= {q[SIZE_W-2:0], ~tmp[SIZE_W+1]};
+
+              a <= a_in;
+
+              if (counter != END_COUNT[COUNT_W-1:0] - 1) begin
+                 counter <= counter + 1'b1;
+                 pc <= pc;
+              end else begin
+                 pc <= 1'b0;
+              end
+           end
+           default:;
+         endcase
+      end
+   end
+
+   assign res_o = q;
+   assign done_o = ~pc;
+              """,
+            },
+        ],
+    }
+
+    return attributes_dict

--- a/examples/reg/iob_reg_e/iob_reg_e.py
+++ b/examples/reg/iob_reg_e/iob_reg_e.py
@@ -1,0 +1,100 @@
+def setup(py_params_dict):
+    attributes_dict = {
+        "original_name": "iob_reg_e",
+        "name": "iob_reg_e",
+        "version": "0.1",
+        "confs": [
+            {
+                "name": "DATA_W",
+                "type": "P",
+                "val": "21",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Data bus width",
+            },
+            {
+                "name": "RST_VAL",
+                "type": "P",
+                "val": "{DATA_W{1'b0}}",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+        ],
+        "ports": [
+            {
+                "name": "clk_en_rst",
+                "interface": {
+                    "type": "clk_en_rst",
+                    "subtype": "slave",
+                },
+                "descr": "Clock, clock enable and reset",
+            },
+            {
+                "name": "en_i",
+                "descr": "Input port",
+                "signals": [
+                    {
+                        "name": "en",
+                        "width": 1,
+                        "direction": "input",
+                    },
+                ],
+            },
+            {
+                "name": "data_i",
+                "descr": "Input port",
+                "signals": [
+                    {
+                        "name": "data",
+                        "width": "DATA_W",
+                        "direction": "input",
+                    },
+                ],
+            },
+            {
+                "name": "data_o",
+                "descr": "Output port",
+                "signals": [
+                    {
+                        "name": "data",
+                        "width": "DATA_W",
+                        "direction": "output",
+                    },
+                ],
+            },
+        ],
+        "wires": [
+            {
+                "name": "data_int",
+                "descr": "data wire",
+                "signals": [
+                    {"name": "data_int", "width": "DATA_W"},
+                ],
+            },
+        ],
+        "blocks": [
+            {
+                "core_name": "iob_reg",
+                "instance_name": "reg0",
+                "parameters": {
+                    "DATA_W": "DATA_W",
+                    "RST_VAL": "RST_VAL",
+                },
+                "connect": {
+                    "clk_en_rst": "clk_en_rst",
+                    "data_i": "data_int",
+                    "data_o": "data_o",
+                },
+            },
+        ],
+        "snippets": [
+            {
+                "verilog_code": """
+        assign data_int = en_i ? data_i : data_o;
+            """,
+            },
+        ],
+    }
+
+    return attributes_dict

--- a/examples/reg/iob_reg_r/hardware/src/iob_reg_r.v
+++ b/examples/reg/iob_reg_r/hardware/src/iob_reg_r.v
@@ -1,0 +1,26 @@
+`timescale 1ns / 1ps
+
+module iob_reg_r #(
+   parameter DATA_W  = 21,
+   parameter RST_VAL = {DATA_W{1'b0}}
+) (
+   `include "clk_en_rst_s_port.vs"
+
+   input rst_i,
+
+   input  [DATA_W-1:0] data_i,
+   output [DATA_W-1:0] data_o
+);
+
+   wire [DATA_W-1:0] data_nxt = rst_i ? RST_VAL : data_i;
+
+   iob_reg #(
+      .DATA_W (DATA_W),
+      .RST_VAL(RST_VAL)
+   ) iob_reg_inst (
+      `include "clk_en_rst_s_s_portmap.vs"
+      .data_i(data_nxt),
+      .data_o(data_o)
+   );
+
+endmodule

--- a/examples/reg/iob_reg_r/iob_reg_r.py
+++ b/examples/reg/iob_reg_r/iob_reg_r.py
@@ -1,0 +1,100 @@
+def setup(py_params_dict):
+    attributes_dict = {
+        "original_name": "iob_reg_r",
+        "name": "iob_reg_r",
+        "version": "0.1",
+        "confs": [
+            {
+                "name": "DATA_W",
+                "type": "P",
+                "val": "21",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Data bus width",
+            },
+            {
+                "name": "RST_VAL",
+                "type": "P",
+                "val": "{DATA_W{1'b0}}",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+        ],
+        "ports": [
+            {
+                "name": "clk_en_rst",
+                "interface": {
+                    "type": "clk_en_rst",
+                    "subtype": "slave",
+                },
+                "descr": "Clock, clock enable and reset",
+            },
+            {
+                "name": "rst",
+                "descr": "Synchronous reset interface",
+                "signals": [
+                    {
+                        "name": "rst",
+                        "width": 1,
+                        "direction": "input",
+                    },
+                ],
+            },
+            {
+                "name": "data_i",
+                "descr": "Input port",
+                "signals": [
+                    {
+                        "name": "data",
+                        "width": "DATA_W",
+                        "direction": "input",
+                    },
+                ],
+            },
+            {
+                "name": "data_o",
+                "descr": "Output port",
+                "signals": [
+                    {
+                        "name": "data",
+                        "width": "DATA_W",
+                        "direction": "output",
+                    },
+                ],
+            },
+        ],
+        "wires": [
+            {
+                "name": "data_next",
+                "descr": "data_next wire",
+                "signals": [
+                    {"name": "data_next", "width": "DATA_W"},
+                ],
+            },
+        ],
+        "blocks": [
+            {
+                "core_name": "iob_reg",
+                "instance_name": "iob_reg_inst",
+                "parameters": {
+                    "DATA_W": "DATA_W",
+                    "RST_VAL": "RST_VAL",
+                },
+                "connect": {
+                    "clk_en_rst": "clk_en_rst",
+                    "data_i": "data_next",
+                    "data_o": "data_o",
+                },
+            },
+        ],
+        "snippets": [
+            {
+                "verilog_code": """
+        assign data_next = rst_i ? RST_VAL : data_i;
+            """,
+            },
+        ],
+    }
+
+    return attributes_dict

--- a/examples/reg/iob_reg_re/iob_reg_re.py
+++ b/examples/reg/iob_reg_re/iob_reg_re.py
@@ -1,0 +1,115 @@
+def setup(py_params_dict):
+    attributes_dict = {
+        "original_name": "iob_reg_re",
+        "name": "iob_reg_re",
+        "version": "0.1",
+        "confs": [
+            {
+                "name": "DATA_W",
+                "type": "P",
+                "val": "21",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Data bus width",
+            },
+            {
+                "name": "RST_VAL",
+                "type": "P",
+                "val": "{DATA_W{1'b0}}",
+                "min": "NA",
+                "max": "NA",
+                "descr": "Reset value.",
+            },
+        ],
+        "ports": [
+            {
+                "name": "clk_en_rst",
+                "interface": {
+                    "type": "clk_en_rst",
+                    "subtype": "slave",
+                },
+                "descr": "Clock, clock enable and reset",
+            },
+            {
+                "name": "en_rst",
+                "descr": "Enable and Synchronous reset interface",
+                "signals": [
+                    {
+                        "name": "en",
+                        "direction": "input",
+                        "width": 1,
+                        "descr": "Enable input",
+                    },
+                    {
+                        "name": "rst",
+                        "direction": "input",
+                        "width": 1,
+                        "descr": "Synchronous reset input",
+                    },
+                ],
+            },
+            {
+                "name": "data_i",
+                "descr": "Input port",
+                "signals": [
+                    {
+                        "name": "data",
+                        "width": "DATA_W",
+                        "direction": "input",
+                    },
+                ],
+            },
+            {
+                "name": "data_o",
+                "descr": "Output port",
+                "signals": [
+                    {
+                        "name": "data",
+                        "width": "DATA_W",
+                        "direction": "output",
+                    },
+                ],
+            },
+        ],
+        "wires": [
+            {
+                "name": "data_int",
+                "descr": "data_int wire",
+                "signals": [
+                    {"name": "data_int", "width": "DATA_W"},
+                ],
+            },
+            {
+                "name": "iob_reg_re_rst",
+                "descr": "iob_reg_re_rst wire",
+                "signals": [
+                    {"name": "rst"},
+                ],
+            },
+        ],
+        "blocks": [
+            {
+                "core_name": "iob_reg_r",
+                "instance_name": "reg0",
+                "parameters": {
+                    "DATA_W": "DATA_W",
+                    "RST_VAL": "RST_VAL",
+                },
+                "connect": {
+                    "clk_en_rst": "clk_en_rst",
+                    "rst": "iob_reg_re_rst",
+                    "data_i": "data_int",
+                    "data_o": "data_o",
+                },
+            },
+        ],
+        "snippets": [
+            {
+                "verilog_code": """
+        assign data_int = en_i ? data_i : data_o;
+            """,
+            },
+        ],
+    }
+
+    return attributes_dict

--- a/py2hwsw/scripts/if_gen.py
+++ b/py2hwsw/scripts/if_gen.py
@@ -893,7 +893,7 @@ def write_single_wire(fout, wire_prefix, wire, for_tb):
     if for_tb:
         wire_name = wire_name + get_suffix(reverse_direction(wire.direction))
         wtype = get_tbsignal_type(wire.direction)
-    if wire.isreg:
+    if wire.isvar:
         wtype = "reg"
     width_str = f" [{wire.width}-1:0] "
     fout.write(wtype + width_str + wire_name + ";\n")

--- a/py2hwsw/scripts/if_gen.py
+++ b/py2hwsw/scripts/if_gen.py
@@ -893,7 +893,7 @@ def write_single_wire(fout, wire_prefix, wire, for_tb):
     if for_tb:
         wire_name = wire_name + get_suffix(reverse_direction(wire.direction))
         wtype = get_tbsignal_type(wire.direction)
-    if wire.isvar:
+    if wire.isvar or wire.isreg:
         wtype = "reg"
     width_str = f" [{wire.width}-1:0] "
     fout.write(wtype + width_str + wire_name + ";\n")

--- a/py2hwsw/scripts/iob_comb.py
+++ b/py2hwsw/scripts/iob_comb.py
@@ -23,6 +23,7 @@ def create_comb(core, *args, **kwargs):
     verilog_code = kwargs.get("verilog_code", None)
     comb = iob_comb(verilog_code=verilog_code)
     comb.set_needed_reg(core)
+    comb.infer_registers(core)
     core.combs.append(comb)
 
 

--- a/py2hwsw/scripts/iob_signal.py
+++ b/py2hwsw/scripts/iob_signal.py
@@ -10,6 +10,8 @@ class iob_signal:
     name: str = ""
     width: str or int = 1
     isvar: bool = False
+    isreg: bool = False
+    reg_signals: list[str] = []
     descr: str = "Default description"
 
     # Only used when signal belongs to a port
@@ -24,7 +26,7 @@ class iob_signal:
 
     def get_verilog_wire(self):
         """Generate a verilog wire string from this signal"""
-        wire_type = "reg" if self.isvar else "wire"
+        wire_type = "reg" if self.isvar or self.isreg else "wire"
         width_str = "" if self.get_width_int() == 1 else f"[{self.width}-1:0] "
         return f"{wire_type} {width_str}{self.name};\n"
 
@@ -36,7 +38,7 @@ class iob_signal:
         """Generate a verilog port string from this signal"""
         self.assert_direction()
         comma_char = "," if comma else ""
-        port_type = " reg" if self.isvar else ""
+        port_type = " reg" if self.isvar or self.isreg else ""
         width_str = "" if self.get_width_int() == 1 else f"[{self.width}-1:0] "
         return f"{self.direction}{port_type} {width_str}{self.get_verilog_port_name()}{comma_char}\n"
 

--- a/py2hwsw/scripts/iob_signal.py
+++ b/py2hwsw/scripts/iob_signal.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from iob_base import fail_with_msg
 
@@ -11,7 +11,7 @@ class iob_signal:
     width: str or int = 1
     isvar: bool = False
     isreg: bool = False
-    reg_signals: list[str] = []
+    reg_signals: list[str] = field(default_factory=list)
     descr: str = "Default description"
 
     # Only used when signal belongs to a port

--- a/py2hwsw/scripts/iob_signal.py
+++ b/py2hwsw/scripts/iob_signal.py
@@ -9,7 +9,7 @@ class iob_signal:
 
     name: str = ""
     width: str or int = 1
-    isreg: bool = False
+    isvar: bool = False
     descr: str = "Default description"
 
     # Only used when signal belongs to a port
@@ -24,7 +24,7 @@ class iob_signal:
 
     def get_verilog_wire(self):
         """Generate a verilog wire string from this signal"""
-        wire_type = "reg" if self.isreg else "wire"
+        wire_type = "reg" if self.isvar else "wire"
         width_str = "" if self.get_width_int() == 1 else f"[{self.width}-1:0] "
         return f"{wire_type} {width_str}{self.name};\n"
 
@@ -36,7 +36,7 @@ class iob_signal:
         """Generate a verilog port string from this signal"""
         self.assert_direction()
         comma_char = "," if comma else ""
-        port_type = " reg" if self.isreg else ""
+        port_type = " reg" if self.isvar else ""
         width_str = "" if self.get_width_int() == 1 else f"[{self.width}-1:0] "
         return f"{self.direction}{port_type} {width_str}{self.get_verilog_port_name()}{comma_char}\n"
 

--- a/py2hwsw/scripts/iob_snippet.py
+++ b/py2hwsw/scripts/iob_snippet.py
@@ -37,14 +37,88 @@ class iob_snippet:
                     signal_name[:-3],
                     process_func=generate_direction_process_func("inout"),
                 )
+            elif signal_name.endswith("_nxt"):
+                signal = find_signal_in_wires(core.wires, signal_name[:-4])
+                signal.isreg = True
+                signal.reg_signals.add("_nxt")
+            elif signal_name.endswith("_rst"):
+                signal = find_signal_in_wires(core.wires, signal_name[:-4])
+                signal.isreg = True
+                signal.reg_signals.add("_rst")
+            elif signal_name.endswith("_en"):
+                signal = find_signal_in_wires(core.wires, signal_name[:-3])
+                signal.isreg = True
+                signal.reg_signals.add("_en")
             else:
                 signal = find_signal_in_wires(core.wires + core.ports, signal_name)
+
             if signal is not None:
                 signal.isvar = True
             else:
                 fail_with_msg(f"output '{signal_name}' not found in wires/ports lists!")
 
+    def infer_registers(self, core):
+        for wire in core.wires:
+            for signal_ref in wire.signals:
+                signal = get_real_signal(signal_ref)
+                if signal.isreg:
+                    reg_type = "iob_reg"
+                    connect = {
+                            "clk_en_rst": "clk_en_rst",
+                            "data_i": f"{signal.name}_nxt",
+                            "data_o": f"{signal.name}"}
+                    if any(reg_signal == "_nxt" for reg_signal in signal.reg_signals):
+                        core.create_wire(name = f"{signal.name}_nxt",
+                                         signals = [
+                                             {
+                                                 "name": f"{signal.name}_nxt",
+                                                 "width": signal.width,
+                                                 "isvar": True
+                                             }])
+                    _reg_signals = []
+                    connect_key = None
+                    if any(reg_signal == "_en" for reg_signal in signal.reg_signals):
+                        _reg_signals.append(
+                                {
+                                    "name": f"{signal.name}_en",
+                                    "width": 1,
+                                    "isvar": True
+                                })
+                        reg_type = "iob_reg_e"
+                        connect_key = "en_i"
+                    if any(reg_signal == "_rst" for reg_signal in signal.reg_signals):
+                        _reg_signals.append(
+                                {
+                                    "name": f"{signal.name}_rst",
+                                    "width": 1,
+                                    "isvar": True
+                                })
+                        if reg_type.endswith("_e"):
+                            reg_type = "iob_reg_re"
+                            connect_key = "en_rst"
+                        else:
+                            reg_type = "iob_reg_r"
+                            connect_key = "rst"
 
+                    if reg_type != "iob_reg":
+                        core.create_wire(name = f"{signal.name}_reg_signals",
+                                         signals = _reg_signals)
+                        connect[connect_key] = f"{signal.name}_reg_signals"
+
+                    if not any(port.name == "clk_en_rst" for port in core.ports):
+                        core.create_port(name = "clk_en_rst",
+                                         interface={
+                                             "type": "clk_en_rst",
+                                             "subtype": "slave"},
+                                         description="Clock enable and reset signal")
+
+                        core.create_instance(core_name = reg_type,
+                                             instance_name = f"{signal.name}_reg",
+                                             parameters = {
+                                                 "DATA_W": signal.width},
+                                                 "RST_VAL": 0},
+                                             connect = connect)
+                                         
 def generate_direction_process_func(direction):
     """Generates a process function that returns a signal if it matches the direction"""
 
@@ -64,4 +138,5 @@ def create_snippet(core, *args, **kwargs):
     core.set_default_attribute("snippets", [])
     snippet = iob_snippet(*args, **kwargs)
     snippet.set_needed_reg(core)
+    snippet.infer_registers(core)
     core.snippets.append(snippet)

--- a/py2hwsw/scripts/iob_snippet.py
+++ b/py2hwsw/scripts/iob_snippet.py
@@ -40,15 +40,15 @@ class iob_snippet:
             elif signal_name.endswith("_nxt"):
                 signal = find_signal_in_wires(core.wires, signal_name[:-4])
                 signal.isreg = True
-                signal.reg_signals.add("_nxt")
+                signal.reg_signals.append("_nxt")
             elif signal_name.endswith("_rst"):
                 signal = find_signal_in_wires(core.wires, signal_name[:-4])
                 signal.isreg = True
-                signal.reg_signals.add("_rst")
+                signal.reg_signals.append("_rst")
             elif signal_name.endswith("_en"):
                 signal = find_signal_in_wires(core.wires, signal_name[:-3])
                 signal.isreg = True
-                signal.reg_signals.add("_en")
+                signal.reg_signals.append("_en")
             else:
                 signal = find_signal_in_wires(core.wires + core.ports, signal_name)
 
@@ -110,14 +110,14 @@ class iob_snippet:
                                          interface={
                                              "type": "clk_en_rst",
                                              "subtype": "slave"},
-                                         description="Clock enable and reset signal")
+                                         descr="Clock enable and reset signal")
 
-                        core.create_instance(core_name = reg_type,
-                                             instance_name = f"{signal.name}_reg",
-                                             parameters = {
-                                                 "DATA_W": signal.width},
-                                                 "RST_VAL": 0},
-                                             connect = connect)
+                    core.create_instance(core_name = reg_type,
+                                         instance_name = f"{signal.name}_reg",
+                                         parameters = {
+                                             "DATA_W": signal.width,
+                                             "RST_VAL": 0},
+                                         connect = connect)
                                          
 def generate_direction_process_func(direction):
     """Generates a process function that returns a signal if it matches the direction"""

--- a/py2hwsw/scripts/iob_snippet.py
+++ b/py2hwsw/scripts/iob_snippet.py
@@ -40,7 +40,7 @@ class iob_snippet:
             else:
                 signal = find_signal_in_wires(core.wires + core.ports, signal_name)
             if signal is not None:
-                signal.isreg = True
+                signal.isvar = True
             else:
                 fail_with_msg(f"output '{signal_name}' not found in wires/ports lists!")
 


### PR DESCRIPTION
If a port or wire is found in the verilog code with a suffix in ("_nst","_en","_rst") a register of the correct type is created automatically.