### PR TITLE
Add support for for loops in iob_fsms

### DIFF
--- a/py2hwsw/scripts/iob_fsm.py
+++ b/py2hwsw/scripts/iob_fsm.py
@@ -11,15 +11,30 @@ class iob_fsm(iob_snippet):
         self.states = self.verilog_code.split("\n\n")
         self.state_reg_width = (len(self.states) - 1).bit_length()
         self.state_names = {}
+        _for_loops = {}
         for i, state in enumerate(self.states):
             tag = re.search(r"^\s*(\w+):", state)
             tag = tag.group(1) if tag else None
             if tag:
+                for_loop = re.search(r"for\s*\(([^)]+)\)", state)
+                for_loop = for_loop.group(1) if for_loop else None
+                if for_loop:
+                    init, cond, update = for_loop.split(";")
+                    _for_loops[tag] = {
+                        "init": init,
+                        "cond": cond,
+                        "update": update
+                    }
+                    #remove for loop from state
+                    state = re.sub(r"for\s*\([^)]+\)", "", state)
                 self.state_names[tag] = i
                 self.states[i] = state.replace(f"{tag}:", "")
         for state_name, i in self.state_names.items():
             for j, state in enumerate(self.states):
                 self.states[j] = state.replace(state_name, f"{self.state_reg_width}'b{i:0{self.state_reg_width}b}")
+        for tag, loop in _for_loops.items():
+            self.states[self.state_names[tag]] = f"{loop['init']};\n{self.states[self.state_names[tag]]}"
+            self.states[self.state_names[tag+"_endfor"]] = f"{self.states[self.state_names[tag+'_endfor']]}\n{loop['update']};\nif ({loop['cond']}) begin\npc_nxt = {self.state_reg_width}'b{self.state_names[tag]:0{self.state_reg_width}b};\nend"
         for i, state in enumerate(self.states[:-1]):
             self.states[i] = f"{i}: begin\n{state}\nend"
         self.states[-1] = f"default: begin\n{self.states[-1]}\nend"

--- a/py2hwsw/scripts/iob_fsm.py
+++ b/py2hwsw/scripts/iob_fsm.py
@@ -8,11 +8,11 @@ class iob_fsm(iob_snippet):
     """Class to represent a Verilog finite state machine in an iob module"""
 
     def __post_init__(self):
-        self.states = self.verilog_code.split("\n\n")
-        self.state_reg_width = (len(self.states) - 1).bit_length()
-        self.state_names = {}
+        _states = self.verilog_code.split("\n\n")
+        self.state_reg_width = (len(_states) - 1).bit_length()
+        _state_names = {}
         _for_loops = {}
-        for i, state in enumerate(self.states):
+        for i, state in enumerate(_states):
             tag = re.search(r"^\s*(\w+):", state)
             tag = tag.group(1) if tag else None
             if tag:
@@ -27,18 +27,18 @@ class iob_fsm(iob_snippet):
                     }
                     #remove for loop from state
                     state = re.sub(r"for\s*\([^)]+\)", "", state)
-                self.state_names[tag] = i
-                self.states[i] = state.replace(f"{tag}:", "")
-        for state_name, i in self.state_names.items():
-            for j, state in enumerate(self.states):
-                self.states[j] = state.replace(state_name, f"{self.state_reg_width}'b{i:0{self.state_reg_width}b}")
+                _state_names[tag] = i
+                _states[i] = state.replace(f"{tag}:", "")
+        for state_name, i in _state_names.items():
+            for j, state in enumerate(_states):
+                _states[j] = state.replace(state_name, f"{self.state_reg_width}'b{i:0{self.state_reg_width}b}")
         for tag, loop in _for_loops.items():
-            self.states[self.state_names[tag]] = f"{loop['init']};\n{self.states[self.state_names[tag]]}"
-            self.states[self.state_names[tag+"_endfor"]] = f"{self.states[self.state_names[tag+'_endfor']]}\n{loop['update']};\nif ({loop['cond']}) begin\npc_nxt = {self.state_reg_width}'b{self.state_names[tag]:0{self.state_reg_width}b};\nend"
-        for i, state in enumerate(self.states[:-1]):
-            self.states[i] = f"{i}: begin\n{state}\nend"
-        self.states[-1] = f"default: begin\n{self.states[-1]}\nend"
-        joined_states = "\n".join(self.states)
+            _states[_state_names[tag]] = f"{loop['init']};\n{_states[_state_names[tag]]}"
+            _states[_state_names[tag+"_endfor"]] = f"{_states[_state_names[tag+'_endfor']]}\n{loop['update']};\nif ({loop['cond']}) begin\npc_nxt = {self.state_reg_width}'b{_state_names[tag]:0{self.state_reg_width}b};\nend"
+        for i, state in enumerate(_states[:-1]):
+            _states[i] = f"{i}: begin\n{state}\nend"
+        _states[-1] = f"default: begin\n{_states[-1]}\nend"
+        joined_states = "\n".join(_states)
         self.verilog_code = f"""
 always @* begin
     pc_nxt = pc + 1;

--- a/py2hwsw/scripts/iob_snippet.py
+++ b/py2hwsw/scripts/iob_snippet.py
@@ -38,7 +38,7 @@ class iob_snippet:
                     process_func=generate_direction_process_func("inout"),
                 )
             elif signal_name.endswith("_nxt"):
-                signal = find_signal_in_wires(core.wires, signal_name[:-4])
+                signal = find_signal_in_wires(core.wires + core.ports, signal_name[:-4])
                 if not signal:
                     fail_with_msg(
                         f"Could not find signal '{signal_name[:-4]}' in wires of '{core.name}' for register implied by '{signal_name}'."
@@ -46,7 +46,7 @@ class iob_snippet:
                 signal.isreg = True
                 signal.reg_signals.append("_nxt")
             elif signal_name.endswith("_rst"):
-                signal = find_signal_in_wires(core.wires, signal_name[:-4])
+                signal = find_signal_in_wires(core.wires + core.ports, signal_name[:-4])
                 if not signal:
                     fail_with_msg(
                         f"Could not find signal '{signal_name[:-4]}' in wires of '{core.name}' for register implied by '{signal_name}'."
@@ -54,7 +54,7 @@ class iob_snippet:
                 signal.isreg = True
                 signal.reg_signals.append("_rst")
             elif signal_name.endswith("_en"):
-                signal = find_signal_in_wires(core.wires, signal_name[:-3])
+                signal = find_signal_in_wires(core.wires + core.ports, signal_name[:-3])
                 if not signal:
                     fail_with_msg(
                         f"Could not find signal '{signal_name[:-3]}' in wires of '{core.name}' for register implied by '{signal_name}'."
@@ -70,7 +70,7 @@ class iob_snippet:
                 fail_with_msg(f"Output '{signal_name}' not found in wires/ports lists!")
 
     def infer_registers(self, core):
-        for wire in core.wires:
+        for wire in core.wires + core.ports:
             for signal_ref in wire.signals:
                 signal = get_real_signal(signal_ref)
                 if signal.isreg:


### PR DESCRIPTION
To use a for loop in an FSM there must be a state with the loop described in front of its tag:
`<tag>: for(<init statement>;<condition statement>;<update statement>)`

The end of the loop must be marked with the same tag with '_endfor' as a suffix:
`<tag>_endfor:`

The 'init statement' will be added to the beginning of the 'tag' state
To the end of the 'tag_endfor' state, the 'update statement will be added followed by
`if (condition statement) begin
    pc_nxt = tag;
end`