### PR TITLE
FIx ci.yml; Add missing regs in csrs module; Resolve issues.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,7 @@ jobs:
           submodules: 'recursive'
       - name: run LIB test
         run: |
-          export py2hwsw_dir=$(pwd);\
-          py2hwsw () { $py2hwsw_dir/py2hwsw/scripts/py2hwsw.py $@; };\
-          export -f py2hwsw;\
+          export PY2HWSW_PATH=$(pwd);\
           cd iob-soc;\
-          py2hwsw --version;\
+          nix-shell --run 'py2hwsw --version';\
           make -C lib/ sim-test;

--- a/py2hwsw/document/Makefile
+++ b/py2hwsw/document/Makefile
@@ -92,6 +92,7 @@ doctop:
 ifeq ($(DOC),rn)
 	echo "\def\RN{Y}" >> $(DOC)top.tex
 endif
+	if [ $(SECTIONCLEARPAGE) ]; then echo "\def\SECTIONCLEARPAGE{Y}" >> $(DOC)top.tex; fi
 	if [ $(RESULTS) ]; then echo "\def\RESULTS{Y}" >> $(DOC)top.tex; fi
 	if [ $(INTEL_FPGA)$(AMD_FPGA) ]; then echo "\def\FPGA{Y}" >> $(DOC)top.tex; fi
 	if [ $(AMD_FPGA) ]; then echo "\def\AMD{Y}" >> $(DOC)top.tex; fi

--- a/py2hwsw/document/tsrc/pb.tex
+++ b/py2hwsw/document/tsrc/pb.tex
@@ -23,21 +23,36 @@ keepaspectratio]{bg.pdf}%
 \section*{Overview}
 \input{intro}
 
+\ifdefined\SECTIONCLEARPAGE
+\clearpage
+\fi
 \section*{Features}
 \input{features}
 
 \newpage
+\ifdefined\SECTIONCLEARPAGE
+\clearpage
+\fi
 \section*{Block Diagram}
 \input{bd}
 
+\ifdefined\SECTIONCLEARPAGE
+\clearpage
+\fi
 \section*{Deliverables}
 \input{deliverables}
 
+\ifdefined\SECTIONCLEARPAGE
+\clearpage
+\fi
 \section*{Benefits}
 \input{benefits}
 
 
 \ifdefined\RESULTS
+\ifdefined\SECTIONCLEARPAGE
+\clearpage
+\fi
 \section*{Implementation Results}
 \input{fpga_results}
 \input{asic_results}

--- a/py2hwsw/document/tsrc/rn.tex
+++ b/py2hwsw/document/tsrc/rn.tex
@@ -26,6 +26,9 @@ version of IP component. The Release Notes provide fundamental information about
 the IP component being released and briefly describes enhancements, new
 features, improvements, etc.
 
+\ifdefined\SECTIONCLEARPAGE
+\clearpage
+\fi
 \section{Release Notes}
 
 \begin{table}[H]

--- a/py2hwsw/document/tsrc/ug.tex
+++ b/py2hwsw/document/tsrc/ug.tex
@@ -46,6 +46,9 @@ User Guide, \input{\NAME_version.tex}, Build \input{shortHash.tex}
 \label{sec:deliv}
 \input{deliverables}
 
+\ifdefined\SECTIONCLEARPAGE
+\clearpage
+\fi
 \section{Description}
 
 This section gives a detailed description of the IP core. The high-level block
@@ -83,6 +86,9 @@ Registers (CSR) are outlined and explained.
 \input{csrs}
 \fi
 
+\ifdefined\SECTIONCLEARPAGE
+\clearpage
+\fi
 \section{Usage}
 
 \subsection{Instantiation}
@@ -106,6 +112,9 @@ Registers (CSR) are outlined and explained.
 \fi
 
 \ifdefined\RESULTS
+\ifdefined\SECTIONCLEARPAGE
+\clearpage
+\fi
 \section{Implementation Results}
 \label{sec:results}
 \input{results}

--- a/py2hwsw/lib/hardware/csrs/scripts/csr_gen.py
+++ b/py2hwsw/lib/hardware/csrs/scripts/csr_gen.py
@@ -452,6 +452,7 @@ class csr_gen:
         """
 
         wires = []
+        blocks = []
         snippet = ""
         # macros
         snippet += """
@@ -467,7 +468,7 @@ class csr_gen:
     localparam WAIT_REQ = 1'd0;
     localparam WAIT_RVALID = 1'd1;
 """
-        wires.append(
+        wires += [
             {
                 "name": "state",
                 "descr": "",
@@ -475,8 +476,30 @@ class csr_gen:
                     {"name": "state", "width": 1},
                 ],
             },
+            {
+                "name": "state_nxt",
+                "descr": "",
+                "signals": [
+                    {"name": "state_nxt", "width": 1, "isreg": True},
+                ],
+            },
+        ]
+        blocks.append(
+            {
+                "core_name": "iob_reg",
+                "instance_name": "state_reg",
+                "instance_description": "state register",
+                "parameters": {
+                    "DATA_W": 1,
+                    "RST_VAL": "1'b0",
+                },
+                "connect": {
+                    "clk_en_rst": "clk_en_rst",
+                    "data_i": "state_nxt",
+                    "data_o": "state",
+                },
+            }
         )
-
 
         # write address
         snippet += "\n    //write address\n"
@@ -512,12 +535,19 @@ class csr_gen:
 
 """
         wires += [
-            # Implicit "iob_reg"
+            # iob_regs
             {
                 "name": "rvalid",
                 "descr": "",
                 "signals": [
                     {"name": "rvalid", "width": 1},
+                ],
+            },
+            {
+                "name": "rvalid_nxt",
+                "descr": "",
+                "signals": [
+                    {"name": "rvalid_nxt", "width": 1, "isreg": True},
                 ],
             },
             {
@@ -528,10 +558,24 @@ class csr_gen:
                 ],
             },
             {
+                "name": "rdata_nxt",
+                "descr": "",
+                "signals": [
+                    {"name": "rdata_nxt", "width": 8*self.cpu_n_bytes, "isreg": True},
+                ],
+            },
+            {
                 "name": "ready",
                 "descr": "",
                 "signals": [
                     {"name": "ready", "width": 1},
+                ],
+            },
+            {
+                "name": "ready_nxt",
+                "descr": "",
+                "signals": [
+                    {"name": "ready_nxt", "width": 1, "isreg": True},
                 ],
             },
             # Wires of type "reg"
@@ -539,22 +583,66 @@ class csr_gen:
                 "name": "rvalid_int",
                 "descr": "",
                 "signals": [
-                    {"name": "rvalid_int", "width": 1},
+                    {"name": "rvalid_int", "width": 1, "isvar": True},
                 ],
             },
             {
                 "name": "wready_int",
                 "descr": "",
                 "signals": [
-                    {"name": "wready_int", "width": 1},
+                    {"name": "wready_int", "width": 1, "isvar": True},
                 ],
             },
             {
                 "name": "rready_int",
                 "descr": "",
                 "signals": [
-                    {"name": "rready_int", "width": 1},
+                    {"name": "rready_int", "width": 1, "isvar": True},
                 ],
+            },
+        ]
+        blocks += [
+            {
+                "core_name": "iob_reg",
+                "instance_name": "rvalid_reg",
+                "instance_description": "rvalid register",
+                "parameters": {
+                    "DATA_W": 1,
+                    "RST_VAL": "1'b0",
+                },
+                "connect": {
+                    "clk_en_rst": "clk_en_rst",
+                    "data_i": "rvalid_nxt",
+                    "data_o": "rvalid",
+                },
+            },
+            {
+                "core_name": "iob_reg",
+                "instance_name": "rdata_reg",
+                "instance_description": "rdata register",
+                "parameters": {
+                    "DATA_W": 8*self.cpu_n_bytes,
+                    "RST_VAL": "1'b0",
+                },
+                "connect": {
+                    "clk_en_rst": "clk_en_rst",
+                    "data_i": "rdata_nxt",
+                    "data_o": "rdata",
+                },
+            },
+            {
+                "core_name": "iob_reg",
+                "instance_name": "ready_reg",
+                "instance_description": "ready register",
+                "parameters": {
+                    "DATA_W": 1,
+                    "RST_VAL": "1'b0",
+                },
+                "connect": {
+                    "clk_en_rst": "clk_en_rst",
+                    "data_i": "ready_nxt",
+                    "data_o": "ready",
+                },
             },
         ]
 
@@ -568,7 +656,7 @@ class csr_gen:
                             "name": aux_read_reg,
                             "descr": "",
                             "signals": [
-                                {"name": aux_read_reg, "width": 1},
+                                {"name": aux_read_reg, "width": 1, "isvar": True},
                             ],
                         },
                     )
@@ -684,6 +772,7 @@ class csr_gen:
 """
 
         core_attributes["wires"] += wires
+        core_attributes["blocks"] += blocks
         core_attributes["snippets"] += [
             {"verilog_code": snippet}
         ]

--- a/py2hwsw/scripts/py2hwsw.py
+++ b/py2hwsw/scripts/py2hwsw.py
@@ -7,7 +7,7 @@ import iob_base
 from iob_base import fail_with_msg
 from iob_core import iob_core
 
-PY2HWSW_VERSION = "0.7.12"
+PY2HWSW_VERSION = "0.7.13"
 
 if __name__ == "__main__":
     sys.dont_write_bytecode = True

--- a/py2hwsw/scripts/py2hwsw.py
+++ b/py2hwsw/scripts/py2hwsw.py
@@ -7,7 +7,7 @@ import iob_base
 from iob_base import fail_with_msg
 from iob_core import iob_core
 
-PY2HWSW_VERSION = "0.7.13"
+PY2HWSW_VERSION = "0.7.14"
 
 if __name__ == "__main__":
     sys.dont_write_bytecode = True


### PR DESCRIPTION
Included in PR: https://github.com/IObundle/iob-soc/pull/940

- Update `ci.yml` to use iob-soc's new `PY2HWSW_PATH` environment variable. This commit fixes issues with py2hwsw not using the correct version for iob-soc/lib test.

- Add missing regs in csrs module (no longer infered).

- Add new makefile (build) variable [`SECTIONCLEARPAGE`](https://github.com/IObundle/py2hwsw/pull/44/files#diff-8478c66c70610d60b5fea9990f2f04be7f600be331eab03f03c715d2ac883c57R95) to select if should insert an optional clearpage after each doc section.
Update documents to include optional clearpage. This should resolve https://github.com/IObundle/py2hwsw/issues/7.

- Add new python parameter [`interrupt_csrs`](https://github.com/IObundle/py2hwsw/pull/44/files#diff-1897540fd1ab2ff5673e78b2187b38657ea28a275f578088fa794bbdd57b7fd5R109) to csrs.py module.
Enabling this parameter will cause the csrs module to automatically add interrupt related registers.
This should resolve https://github.com/IObundle/py2hwsw/issues/35

- Add new python parameter [`fifo_csrs`](https://github.com/IObundle/py2hwsw/pull/44/files#diff-1897540fd1ab2ff5673e78b2187b38657ea28a275f578088fa794bbdd57b7fd5R111) to csrs.py module.
Passing a FIFO names list to this parameter will cause the csrs module to generate FIFO related registers for each given FIFO name. Currently this does not create the FIFO itself, only the registers.
Progress towards https://github.com/IObundle/py2hwsw/issues/34.
If FIFOs are meant to be created and connected manually, then the issue is resolved.