### PR TITLE
Shorthand notation changed to look like command line

### DIFF
--- a/py2hwsw/lib/hardware/arith_logic/iob_int_sqrt/iob_int_sqrt.py
+++ b/py2hwsw/lib/hardware/arith_logic/iob_int_sqrt/iob_int_sqrt.py
@@ -5,13 +5,24 @@ def setup(py_params_dict):
         "version": "0.1",
         "confs": [
             """
-            DATA_W P 32 $mNA $MNA $D'Data bus width'
-            FRACTIONAL_W P 0 $mNA $MNA $D'Fractional part width'
-            REAL_W P 'DATA_W - FRACTIONAL_W' $mNA $MNA $D'Real part width'
+            DATA_W -t P -v 32 -m NA -M NA
+            Data bus width
+
+            FRACTIONAL_W -t P -v 0 -m NA -M NA
+            Fractional part width
+
+            REAL_W -t P -v 'DATA_W - FRACTIONAL_W' -m NA -M NA
+            Real part width
+
+            SIZE_W -t P -v '(REAL_W / 2) + FRACTIONAL_W' -m NA -M NA
+            Size width
+
+            END_COUNT -t F -v '(DATA_W + FRACTIONAL_W) >> 1' -m NA -M NA
+            End count
+
+            COUNT_W -t F -v $clog2(END_COUNT) -m NA -M NA
+            Count width
             """,
-            "SIZE_W P '(REAL_W / 2) + FRACTIONAL_W' $mNA $MNA $D'Size width'",
-            "END_COUNT F '(DATA_W + FRACTIONAL_W) >> 1' $mNA $MNA $D'End count'",
-            "COUNT_W F '$clog2(END_COUNT)' $mNA $MNA $D'Count width'",
         ],
         "ports": [
             {

--- a/py2hwsw/scripts/iob_base.py
+++ b/py2hwsw/scripts/iob_base.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import shlex
+import argparse
 from dataclasses import dataclass
 import importlib
 import traceback
@@ -182,7 +184,7 @@ def debug(msg, level=0):
 #
 
 
-def str_to_kwargs(attrs: dict = {}):
+def str_to_kwargs(attrs: list):
     """Decorator to convert a string to keyword arguments
     Any method decorated with str_to_kwargs can take a string as its argument 
     The string must be of the form: 'arg0 arg1 arg2 $<letter>kwarg0 $<letter>kwarg1 ...'
@@ -194,18 +196,18 @@ def str_to_kwargs(attrs: dict = {}):
         @wraps(func)
         def wrapper(core, *args, **kwargs):
             if len(args) == 1 and isinstance(args[0], str):
-                lines = [line for line in args[0].split('\n') if line.strip()]
+                parser = argparse.ArgumentParser()
+                for attr in attrs:
+                    if isinstance(attr, str):
+                        parser.add_argument(attr)
+                    else:
+                        parser.add_argument(attr[0], dest=attr[1])
+                lines = [line.strip() for line in args[0].split("\n\n") if line.strip()]
                 for line in lines:
-                    parts = re.findall(r"(?:\$\w)?(?:'[^']*'|\S+)", line)
-                    new_kwargs = {}
-                    for key, value in enumerate([arg for arg in parts if not arg.startswith("$")]):
-                        new_kwargs[attrs[key]] = value.strip("'")
-                    for i in parts:
-                        if i.startswith("$"):
-                            key = attrs[i[1]]
-                            value = i[2:]
-                            new_kwargs[key] = value.strip("'")
-                    func(core, **new_kwargs)
+                    line, descr = line.split("\n", 1)
+                    parts = shlex.split(line)
+                    args = parser.parse_args(parts)
+                    func(core, descr=descr.strip(), **vars(args))
                 return None 
             else:
                 return func(core, *args, **kwargs)

--- a/py2hwsw/scripts/iob_conf.py
+++ b/py2hwsw/scripts/iob_conf.py
@@ -21,7 +21,7 @@ class iob_conf:
         elif self.type not in ["M", "P", "F"]:
             raise Exception("Conf type must be either M, P or F")
 
-attrs = {0: "name", 1: "type", 2: "val", "m": "min", "M": "max", "D": "descr"}
+attrs = ["name", ["-t", "type"], ["-v", "val"], ["-m", "min"], ["-M", "max"]]
 @str_to_kwargs(attrs)
 def create_conf(core, *args, **kwargs):
     """Creates a new conf object and adds it to the core's conf list


### PR DESCRIPTION
Shorthand notation now resembles the command line by using flags instead of $<letter>
The description is mandatory and always starts on the second line and can take multiple lines
iob_int_sqrt has its confs described with the new notation and can be seen as an example