### PR TITLE
fix(console): faster serial read

### DIFF
--- a/py2hwsw/scripts/console.py
+++ b/py2hwsw/scripts/console.py
@@ -72,13 +72,12 @@ def tb_read_file(number_of_bytes):
 
 
 def serial_read(number_of_bytes):
-    data = b""
+    data_bytes = []
     i = 0
     while i < number_of_bytes:
-        byte = ser.read(1)
-        data += byte
+        data_bytes.append(ser.read(1))
         i = i + 1
-    return data
+    return b"".join(data_bytes)
 
 
 # Print ERROR


### PR DESCRIPTION
implement serial read with bytestring list and concatenate all bytes at the end. 
This implementation is better for large file since the original code: 
```python 
data += byte 
``` 
becomes progressively slower for large bytestrings. 
Python allocates a new space for the result string and copies both strings into it. 
This becomes so slow that the console misses some bytes sent by IOB-SOC at around ~1MB bytestrings.