### PR TITLE
fix(questa): clean target calls gen-clean

### DIFF
--- a/py2hwsw/hardware/simulation/questa.mk
+++ b/py2hwsw/hardware/simulation/questa.mk
@@ -22,7 +22,7 @@ comp: $(VHDR) $(VSRC) $(HEX)
 exec: comp
 	vsim $(SFLAGS) $(NAME)_tb -do "run -all;quit"
 
-clean:
+clean: gen-clean
 	@rm -f *.raw
 
 very-clean:


### PR DESCRIPTION
- update `questa.mk` `clean` target to match other `SIMULATOR.mk` targets