### PR TITLE
Add `iob_address_translator` module.

### DIFF
--- a/py2hwsw/lib/hardware/buses/iob_address_translator/iob_address_translator.py
+++ b/py2hwsw/lib/hardware/buses/iob_address_translator/iob_address_translator.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2024 IObundle
+#
+# SPDX-License-Identifier: MIT
+
+interfaces = {
+    "iob": [
+        ("valid", "output", 1),
+        ("addr", "output", "ADDR_W", 32),
+        ("wdata", "output", "DATA_W", 32),
+        ("wstrb", "output", "DATA_W / 8", 4),
+        ("rvalid", "input", 1),
+        ("rdata", "input", "DATA_W", 32),
+        ("ready", "input", 1),
+    ],
+    "axil": [
+        ("awaddr", "output", "ADDR_W", 32),
+        ("awprot", "output", "PROT_W", 3),
+        ("awvalid", "output", 1),
+        ("awready", "input", 1),
+        ("wdata", "output", "DATA_W", 32),
+        ("wstrb", "output", "DATA_W / 8", 4),
+        ("wvalid", "output", 1),
+        ("wready", "input", 1),
+        ("bresp", "input", "RESP_W", 2),
+        ("bvalid", "input", 1),
+        ("bready", "output", 1),
+        ("araddr", "output", "ADDR_W", 32),
+        ("arprot", "output", "PROT_W", 3),
+        ("arvalid", "output", 1),
+        ("arready", "input", 1),
+        ("rdata", "input", "DATA_W", 32),
+        ("rresp", "input", "RESP_W", 2),
+        ("rvalid", "input", 1),
+        ("rready", "output", 1),
+    ],
+    "axi": [
+        ("awaddr", "output", "ADDR_W", 32),
+        ("awprot", "output", "PROT_W", 3),
+        ("awvalid", "output", 1),
+        ("awready", "input", 1),
+        ("wdata", "output", "DATA_W", 32),
+        ("wstrb", "output", "DATA_W / 8", 4),
+        ("wvalid", "output", 1),
+        ("wready", "input", 1),
+        ("bresp", "input", "RESP_W", 2),
+        ("bvalid", "input", 1),
+        ("bready", "output", 1),
+        ("araddr", "output", "ADDR_W", 32),
+        ("arprot", "output", "PROT_W", 3),
+        ("arvalid", "output", 1),
+        ("arready", "input", 1),
+        ("rdata", "input", "DATA_W", 32),
+        ("rresp", "input", "RESP_W", 2),
+        ("rvalid", "input", 1),
+        ("rready", "output", 1),
+        ("awid", "output", "ID_W", 1),
+        ("awlen", "output", "LEN_W", 8),
+        ("awsize", "output", "SIZE_W", 3),
+        ("awburst", "output", "BURST_W", 2),
+        ("awlock", "output", "LOCK_W", 2),
+        ("awcache", "output", "CACHE_W", 4),
+        ("awqos", "output", "QOS_W", 4),
+        ("wlast", "output", 1),
+        ("bid", "input", "ID_W", 1),
+        ("arid", "output", "ID_W", 1),
+        ("arlen", "output", "LEN_W", 8),
+        ("arsize", "output", "SIZE_W", 3),
+        ("arburst", "output", "BURST_W", 2),
+        ("arlock", "output", "LOCK_W", 2),
+        ("arcache", "output", "CACHE_W", 4),
+        ("arqos", "output", "QOS_W", 4),
+        ("rid", "input", "ID_W", 1),
+        ("rlast", "input", 1),
+    ],
+}
+
+
+def setup(py_params_dict):
+    """Core to translate addresses to access configurable memory zones.
+    Use verilog parameters to define widths of each bus.
+    :param str interface: Type of interface for buses.
+    :param str name: Name of the generated verilog core.
+    :param list memory_zones: List of tuples describing each memory zone and offset to add for translation.
+    """
+    INTERFACE = py_params_dict.get("interface", "axi")
+    NAME = py_params_dict.get("name", f"iob_{INTERFACE}_address_translator")
+    MEMORY_ZONES = py_params_dict.get(
+        "memory_zones",
+        [
+            # (Initial zone address, Last zone address (inclusive), Offset to add (for translation))
+        ],
+    )
+    assert MEMORY_ZONES, """
+No memory zones defined for address translation!
+Memory zones must be configured via the 'memory_zones' python parameter.
+Memory zone tuple syntax: (Initial zone address, Last zone address (inclusive), Offset to add (for translation))
+"""
+
+    verilog_snippet = ""
+    parameter_names = []
+    verilog_parameters = []
+    interface_parameters = {}
+
+    #
+    # Create verilog parameters
+    #
+    for signal in interfaces[INTERFACE]:
+        name = signal[0]
+        width = signal[2]
+        default_width = signal[2] if type(width) is int else signal[3]
+
+        # Only create verilog parameters for strings that represent widths
+        if type(width) is int or not width.endswith("_W"):
+            continue
+
+        # Don't create a duplicate parameters
+        if width in parameter_names:
+            continue
+        parameter_names.append(width)
+
+        # Set verilog parameters
+        verilog_parameters += [
+            {
+                "name": width,
+                "type": "P",
+                "val": default_width,
+                "min": "1",
+                "max": "32",
+                "descr": f"{width[:-2]} bus width",
+            },
+        ]
+        # Set parameters for if_gen generation of the interface
+        interface_parameters[width] = width
+
+    #
+    # Connect interfaces
+    #
+    for signal in interfaces[INTERFACE]:
+        name = signal[0]
+        # Skip address signal
+        if "addr" in name:
+            continue
+        # Connect both interfaces
+        verilog_snippet += f"""\
+   assign {INTERFACE}_{name}_o = {INTERFACE}_{name}_i;
+"""
+
+    #
+    # Translate addresses to configurable memory zones
+    #
+    translation_snippet_body = "      "
+    for zone in MEMORY_ZONES:
+        zone_start, zone_end, offset = zone
+        translation_snippet_body += f"""\
+if (signal_name_i >= 'h{zone_start:x} && signal_name_i <= 'h{zone_end:x}) begin
+         signal_name_reg = signal_name_i + 'h{offset:x}; // signal_name_i is in the range 0x{zone_start:x} to 0x{zone_end:x}
+      end else \
+"""
+
+    translation_snippet_body += """\
+begin
+         signal_name_reg = signal_name_i; // Default case
+      end
+"""
+
+    for signal in interfaces[INTERFACE]:
+        name = INTERFACE + "_" + signal[0]
+        if "addr" not in name:
+            continue
+        verilog_snippet += f"""
+   // Translate {name} signal
+   reg [ADDR_W-1:0] {name}_reg;
+   assign {name}_o = {name}_reg;
+   always @(*) begin
+{translation_snippet_body.replace("signal_name", name)}
+   end
+"""
+
+    #
+    # Core attributes dictionary
+    #
+    attributes_dict = {
+        "name": NAME,
+        "version": "0.1",
+        "confs": verilog_parameters,
+        "ports": [
+            {
+                "name": "slave_s",
+                "descr": "Slave interface (connects to master)",
+                "signals": {
+                    "type": INTERFACE,
+                    **interface_parameters,
+                },
+            },
+            {
+                "name": "master_m",
+                "descr": "Master interface (connects to slave)",
+                "signals": {
+                    "type": INTERFACE,
+                    **interface_parameters,
+                },
+            },
+        ],
+        "snippets": [{"verilog_code": verilog_snippet}],
+    }
+
+    return attributes_dict

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
@@ -759,9 +759,7 @@ class csr_gen:
 
         # compute write address
         snippet += "    wire [ADDR_W-1:0] waddr;\n"
-        snippet += (
-            "    assign waddr = `IOB_WORD_ADDR(internal_iob_addr_stable) + byte_offset;\n"
-        )
+        snippet += "    assign waddr = `IOB_WORD_ADDR(internal_iob_addr_stable) + byte_offset;\n"
 
         # insert write register logic
         for row in table:

--- a/py2hwsw/lib/hardware/iob_system/hardware/simulation/iob_system_sim.py
+++ b/py2hwsw/lib/hardware/iob_system/hardware/simulation/iob_system_sim.py
@@ -238,11 +238,11 @@ def setup(py_params_dict):
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
                     "cbus_s": (
-                    "ethernet_s",
-                    [
-                        "ethernet_iob_addr_i[12-1:2]",
-                    ],
-                ),
+                        "ethernet_s",
+                        [
+                            "ethernet_iob_addr_i[12-1:2]",
+                        ],
+                    ),
                     "axi_m": "eth_axi",
                     "inta_o": "eth_int",
                     "phy_io": "eth_phy_invert",

--- a/py2hwsw/lib/hardware/iob_system/iob_system.py
+++ b/py2hwsw/lib/hardware/iob_system/iob_system.py
@@ -356,7 +356,7 @@ def setup(py_params_dict):
         },
         {
             "core_name": "iob_axi_interconnect_wrapper",
-            "name": params["name"]+"_axi_interconnect_wrapper",
+            "name": params["name"] + "_axi_interconnect_wrapper",
             "instance_name": "iob_axi_interconnect",
             "instance_description": "Interconnect instance",
             "parameters": {
@@ -458,7 +458,7 @@ def setup(py_params_dict):
         },
         {
             "core_name": "iob_split",
-            "name": params["name"]+"_pbus_split",
+            "name": params["name"] + "_pbus_split",
             "instance_name": "iob_pbus_split",
             "instance_description": "Split between peripherals",
             "connect": {

--- a/py2hwsw/lib/hardware/iob_system/scripts/iob_system_utils.py
+++ b/py2hwsw/lib/hardware/iob_system/scripts/iob_system_utils.py
@@ -291,12 +291,14 @@ def generate_makefile_segments(attributes_dict, peripherals, params, py_params):
             file.write(
                 'CONSOLE_CMD ?=rm -f soc2cnsl cnsl2soc; $(IOB_CONSOLE_PYTHON_ENV) $(PYTHON_DIR)/console_ethernet.py -L -c $(PYTHON_DIR)/console.py -m "$(RMAC_ADDR)" -i "$(ETH_IF)"\n',
             )
-            file.write("""
+            file.write(
+                """
 UTARGETS+=iob_eth_rmac.h
 EMUL_HDR+=iob_eth_rmac.h
 iob_eth_rmac.h:
 	echo "#define ETH_RMAC_ADDR 0x$(RMAC_ADDR)" > $@\n
-""",)
+""",
+            )
 
     #
     # Create auto_fpga_build.mk


### PR DESCRIPTION
New `iob_address_translator` module translates addresses based on configurable memory zones.
Each memory zone is configured by a python tuple with three elements:
1) Start address of the zone.
2) End address of the zone (inclusive).
3) Offset to sum with the original address, in order to translate it to the new address space.

If the master tries to access an address in a memory zone, the translation will be applied by summing the corresponding offset.
Otherwise, no translation is applied.

Example with 3 memory zones:
```Python
{
   "core_name": "iob_address_translator",
   "instance_name": "address_translator",
   "instance_description": "Translate addresses to access memory zones",
   "parameters": {
       "ID_W": "AXI_ID_W",
       "ADDR_W": params["addr_w"] - 2,
       "DATA_W": params["data_w"],
       "LEN_W": "AXI_LEN_W",
       "LOCK_W": "1",
   },
   "connect": {
       "slave_s": "cpu_dbus",
       "master_m": "cpu_dbus2",
   },
   "memory_zones": [
   #   (Start addr, End addr  , Translation offset)
       # If cpu tries to access 0x00000001, it will be translated to 0x30000001.
       (0x00000000, 0x00007FFF, 0x30000000),
       # If cpu tries to access 0x10000001, it will be translated to 0x20000001.
       (0x10000000, 0x20007FFF, 0x10000000),
       # If cpu tries to access 0x20008001, it will be translated to 0x20008002.
       (0x20008000, 0x20008010, 0x00000001),
   ],
},
```

This new module can be used as an alternative to solution proposed in comment: https://github.com/IObundle/py2hwsw/issues/71#issuecomment-2508952526


This PR also formats code in other modules.