### PR TITLE
fix(CDC, doc): axistream_in nword CDC. Doc typo

### DIFF
--- a/py2hwsw/document/tsrc/synth.tex
+++ b/py2hwsw/document/tsrc/synth.tex
@@ -10,5 +10,5 @@ After synthesis, reports on silicon area usage, power consumption, and timing
 closure are generated. A post-synthesis Verilog file is created, which can be
 used in post-synthesis simulation. The IP core has been synthesized without the
 FIFO memories, which are treated as black boxes. RAM subblocks are not included as
-they are technonoly dependent. The user is free to generate and add the required
+they are technology dependent. The user is free to generate and add the required
 memories, or request this service from the IP core provider.

--- a/py2hwsw/lib/hardware/buses/iob_axistream_in/iob_axistream_in.py
+++ b/py2hwsw/lib/hardware/buses/iob_axistream_in/iob_axistream_in.py
@@ -366,6 +366,14 @@ def setup(py_params_dict):
                 "core_name": "iob_edge_detect",
                 "instantiate": False,
             },
+            {
+                "core_name": "iob_gray_counter",
+                "instantiate": False,
+            },
+            {
+                "core_name": "iob_gray2bin",
+                "instantiate": False,
+            },
         ],
         "superblocks": [
             # Simulation wrapper


### PR DESCRIPTION
- fix axistream_in nword CDC: use gray counter for nwords -> sync to CSR clk -> gray2bin -> nword_rd
  - addresses IObundle/py2hwsw#63
- fix documentation typo