### PR TITLE
feat(csrs): Rename cbus port to remove corename from prefix.

### DIFF
--- a/py2hwsw/lib/hardware/basic_tests/iob_csrs_demo/hardware/simulation/src/iob_csrs_demo_tb.v
+++ b/py2hwsw/lib/hardware/basic_tests/iob_csrs_demo/hardware/simulation/src/iob_csrs_demo_tb.v
@@ -53,17 +53,17 @@ module iob_csrs_demo_tb;
    //instantiate iob_csrs_demo core
    iob_csrs_demo iob_csrs_demo0 (
       // clk_en_rst_s port
-      .clk_i                          (clk),
-      .cke_i                          (1'b1),
-      .arst_i                         (rst),
+      .clk_i                (clk),
+      .cke_i                (1'b1),
+      .arst_i               (rst),
       // cbus_s port
-      .iob_csrs_demo_csrs_iob_valid_i (iob_valid_i),
-      .iob_csrs_demo_csrs_iob_addr_i  (iob_addr_i[`IOB_CSRS_DEMO_CSRS_ADDR_W-1:2]),
-      .iob_csrs_demo_csrs_iob_wdata_i (iob_wdata_i),
-      .iob_csrs_demo_csrs_iob_wstrb_i (iob_wstrb_i),
-      .iob_csrs_demo_csrs_iob_rvalid_o(iob_rvalid_o),
-      .iob_csrs_demo_csrs_iob_rdata_o (iob_rdata_o),
-      .iob_csrs_demo_csrs_iob_ready_o (iob_ready_o)
+      .iob_csrs_iob_valid_i (iob_valid_i),
+      .iob_csrs_iob_addr_i  (iob_addr_i[`IOB_CSRS_DEMO_CSRS_ADDR_W-1:2]),
+      .iob_csrs_iob_wdata_i (iob_wdata_i),
+      .iob_csrs_iob_wstrb_i (iob_wstrb_i),
+      .iob_csrs_iob_rvalid_o(iob_rvalid_o),
+      .iob_csrs_iob_rdata_o (iob_rdata_o),
+      .iob_csrs_iob_ready_o (iob_ready_o)
    );
 
 endmodule

--- a/py2hwsw/lib/hardware/basic_tests/iob_csrs_demo/iob_csrs_demo.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_csrs_demo/iob_csrs_demo.py
@@ -398,7 +398,7 @@ def setup(py_params_dict):
         "subblocks": [
             {
                 "core_name": "iob_csrs",
-                "instance_name": "iob_csrs_demo_csrs",
+                "instance_name": "iob_csrs",
                 "instance_description": "Control/Status Registers",
                 "csrs": [
                     {

--- a/py2hwsw/lib/iob_system/hardware/simulation/iob_system_sim.py
+++ b/py2hwsw/lib/iob_system/hardware/simulation/iob_system_sim.py
@@ -228,7 +228,7 @@ def setup(py_params_dict):
             "csr_if": "iob",
             "connect": {
                 "clk_en_rst_s": "clk_en_rst_s",
-                "iob_uart_csrs_cbus_s": (
+                "iob_csrs_cbus_s": (
                     "uart_s",
                     [
                         "uart_iob_addr_i[3-1:2]",
@@ -283,7 +283,7 @@ def setup(py_params_dict):
                 },
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
-                    "iob_eth_csrs_cbus_s": (
+                    "iob_csrs_cbus_s": (
                         "ethernet_s",
                         [
                             "ethernet_iob_addr_i[12-1:2]",

--- a/py2hwsw/lib/iob_system/iob_system.py
+++ b/py2hwsw/lib/iob_system/iob_system.py
@@ -523,7 +523,7 @@ def setup(py_params_dict):
                 },
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
-                    "iob_bootrom_csrs_cbus_s": (
+                    "iob_csrs_cbus_s": (
                         "bootrom_cbus",
                         [
                             "{1'b0, bootrom_axi_arlock}",

--- a/py2hwsw/lib/iob_system/scripts/iob_system_utils.py
+++ b/py2hwsw/lib/iob_system/scripts/iob_system_utils.py
@@ -206,7 +206,7 @@ def connect_peripherals_cbus(attributes_dict, peripherals, params):
         pbus_split["connect"][f"output_{idx}_m"] = f"{peripheral_name}_cbus"
         # Connect cbus to peripheral
         peripheral["connect"][
-            f"{peripheral['core_name']}_csrs_cbus_s"
+            "iob_csrs_cbus_s"
         ] = f"{peripheral_name}_cbus"
 
     # Add CLINT and PLIC wires (they are not in peripherals list)

--- a/py2hwsw/lib/iob_system/submodules/BOOTROM/iob_bootrom.py
+++ b/py2hwsw/lib/iob_system/submodules/BOOTROM/iob_bootrom.py
@@ -101,7 +101,7 @@ def setup(py_params_dict):
         "subblocks": [
             {
                 "core_name": "iob_csrs",
-                "instance_name": "iob_bootrom_csrs",
+                "instance_name": "iob_csrs",
                 "version": VERSION,
                 "csrs": [
                     {

--- a/py2hwsw/lib/peripherals/iob_axistream_in/iob_axistream_in.py
+++ b/py2hwsw/lib/peripherals/iob_axistream_in/iob_axistream_in.py
@@ -213,7 +213,7 @@ def setup(py_params_dict):
         "subblocks": [
             {
                 "core_name": "iob_csrs",
-                "instance_name": "iob_axistream_in_csrs",
+                "instance_name": "iob_csrs",
                 "instance_description": "Control/Status Registers",
                 "csrs": [
                     {

--- a/py2hwsw/lib/peripherals/iob_axistream_out/iob_axistream_out.py
+++ b/py2hwsw/lib/peripherals/iob_axistream_out/iob_axistream_out.py
@@ -205,7 +205,7 @@ def setup(py_params_dict):
         "subblocks": [
             {
                 "core_name": "iob_csrs",
-                "instance_name": "iob_axistream_out_csrs",
+                "instance_name": "iob_csrs",
                 "instance_description": "Control/Status Registers",
                 "csrs": [
                     {

--- a/py2hwsw/lib/peripherals/iob_gpio/iob_gpio.py
+++ b/py2hwsw/lib/peripherals/iob_gpio/iob_gpio.py
@@ -160,7 +160,7 @@ def setup(py_params_dict):
     attributes_dict["subblocks"] = [
         {
             "core_name": "iob_csrs",
-            "instance_name": "iob_gpio_csrs",
+            "instance_name": "iob_csrs",
             "instance_description": "Control/Status Registers",
             "csrs": [
                 {

--- a/py2hwsw/lib/peripherals/iob_nco/hardware/simulation/src/iob_nco_tb.v
+++ b/py2hwsw/lib/peripherals/iob_nco/hardware/simulation/src/iob_nco_tb.v
@@ -88,17 +88,17 @@ module iob_nco_tb;
 
    iob_nco nco (
       `include "iob_nco_clk_en_rst_s_portmap.vs"
-      .clk_in_i                 (clk_in),
-      .clk_in_arst_i            (arst),
-      .clk_in_cke_i             (1'b1),
-      .iob_nco_csrs_iob_valid_i (iob_valid_i),
-      .iob_nco_csrs_iob_addr_i  (iob_addr_i[`IOB_NCO_CSRS_ADDR_W-1:2]),
-      .iob_nco_csrs_iob_wdata_i (iob_wdata_i),
-      .iob_nco_csrs_iob_wstrb_i (iob_wstrb_i),
-      .iob_nco_csrs_iob_rdata_o (iob_rdata_o),
-      .iob_nco_csrs_iob_ready_o (iob_ready_o),
-      .iob_nco_csrs_iob_rvalid_o(iob_rvalid_o),
-      .clk_out_o                (clk_out)
+      .clk_in_i             (clk_in),
+      .clk_in_arst_i        (arst),
+      .clk_in_cke_i         (1'b1),
+      .iob_csrs_iob_valid_i (iob_valid_i),
+      .iob_csrs_iob_addr_i  (iob_addr_i[`IOB_NCO_CSRS_ADDR_W-1:2]),
+      .iob_csrs_iob_wdata_i (iob_wdata_i),
+      .iob_csrs_iob_wstrb_i (iob_wstrb_i),
+      .iob_csrs_iob_rdata_o (iob_rdata_o),
+      .iob_csrs_iob_ready_o (iob_ready_o),
+      .iob_csrs_iob_rvalid_o(iob_rvalid_o),
+      .clk_out_o            (clk_out)
    );
 
    `include "iob_nco_csrs_emb_tb.vs"

--- a/py2hwsw/lib/peripherals/iob_nco/iob_nco.py
+++ b/py2hwsw/lib/peripherals/iob_nco/iob_nco.py
@@ -107,7 +107,7 @@ def setup(py_params_dict):
         "subblocks": [
             {
                 "core_name": "iob_csrs",
-                "instance_name": "iob_nco_csrs",
+                "instance_name": "iob_csrs",
                 "instance_description": "Control/Status Registers",
                 "csrs": [
                     {

--- a/py2hwsw/lib/peripherals/iob_regfileif/iob_regfileif.py
+++ b/py2hwsw/lib/peripherals/iob_regfileif/iob_regfileif.py
@@ -176,7 +176,7 @@ def setup(py_params_dict):
         "subblocks": [
             {
                 "core_name": "iob_csrs",
-                "instance_name": "iob_regfileif_csrs_external",
+                "instance_name": "iob_csrs_external",
                 "instance_description": "Control/Status Registers for external CPU",
                 "csrs": params["csrs"],
                 "connect": {
@@ -192,7 +192,7 @@ def setup(py_params_dict):
             {
                 "core_name": "iob_csrs",
                 "name": attributes_dict["name"] + "_inverted_csrs",
-                "instance_name": "iob_regfileif_csrs",
+                "instance_name": "iob_csrs",
                 "instance_description": "Control/Status Registers for internal CPU (inverted registers)",
                 "csrs": csrs_inverted,
                 "connect": {

--- a/py2hwsw/lib/peripherals/iob_timer/iob_timer.py
+++ b/py2hwsw/lib/peripherals/iob_timer/iob_timer.py
@@ -94,7 +94,7 @@ def setup(py_params_dict):
         "subblocks": [
             {
                 "core_name": "iob_csrs",
-                "instance_name": "iob_timer_csrs",
+                "instance_name": "iob_csrs",
                 "instance_description": "Control/Status Registers",
                 "csrs": [
                     {

--- a/py2hwsw/lib/peripherals/iob_uart/hardware/simulation/src/iob_uart_tb.cpp
+++ b/py2hwsw/lib/peripherals/iob_uart/hardware/simulation/src/iob_uart_tb.cpp
@@ -58,7 +58,7 @@ void iob_write(uint32_t addr, uint32_t data) {
   dut->iob_uart_csrs_addr_i = addr;
   dut->iob_uart_csrs_wdata_i = data;
   dut->iob_uart_csrs_we_i = 1;
-  while (!dut->iob_uart_csrs_iob_ready_o) {
+  while (!dut->iob_csrs_iob_ready_o) {
     tick();
   }
   tick();
@@ -70,7 +70,7 @@ uint32_t iob_read(uint32_t addr) {
   dut->iob_uart_csrs_addr_i = addr;
   dut->iob_uart_csrs_we_i = 0;
   tick();
-  while (!dut->iob_uart_csrs_iob_ready_o) {
+  while (!dut->iob_csrs_iob_ready_o) {
     tick();
   }
   tick();

--- a/py2hwsw/lib/peripherals/iob_uart/iob_uart.py
+++ b/py2hwsw/lib/peripherals/iob_uart/iob_uart.py
@@ -150,8 +150,8 @@ def setup(py_params_dict):
         ],
         "subblocks": [
             # iob_csrs 'control_if_s' port is connected automatically by py2hwsw
-            f"""iob_csrs iob_uart_csrs 
-				-d 'Control/Status Registers' 
+            f"""iob_csrs iob_csrs
+                -d 'Control/Status Registers' 
                 --no_autoaddr 
                 --rw_overlap 
                 -c 
@@ -165,14 +165,13 @@ def setup(py_params_dict):
                     "rxready_i":"rxready"
                     "rxdata_io":"rxdata"
                 --csr_if {CSR_IF}
-                --csr-group 
-				    uart 
+                --csr-group uart 
                     -d 'UART software accessible registers' 
                         -r softreset:1 -t W -d 'Soft reset'  --rst_val 0 --addr 0 --log2n_items 0
                         -r div:16 -t W -d 'Bit duration in system clock cycles.' --rst_val 0 --addr 2 --log2n_items 0
                         -r txdata:8 -t W -d 'TX data.' --rst_val 0 --addr 4 --log2n_items 0 --no_autoreg
                         -r txen:1 -t W -d 'TX enable.' --rst_val 0 --addr 5 --log2n_items 0
-				        -r rxen:1 -t W -d 'RX enable.' --rst_val 0 --addr 6 --log2n_items 0
+                        -r rxen:1 -t W -d 'RX enable.' --rst_val 0 --addr 6 --log2n_items 0
                         -r txready:1 -t R -d 'TX ready to receive data.' --rst_val 0 --addr 0 --log2n_items 0
                         -r rxready:1 -t R -d 'RX ready to be read.' --rst_val 0 --addr 1 --log2n_items 0
                         -r rxdata:8 -t R -d 'RX data.' --rst_val 0 --addr 4 --log2n_items 0 --no_autoreg

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -474,7 +474,7 @@ class iob_core(iob_module, iob_instance):
             for subblock in subblock_group.blocks:
                 for port in subblock.ports:
                     if (
-                        port.name == subblock.original_name + "_csrs_cbus_s"
+                        port.name == "iob_csrs_cbus_s"
                         and port.interface.type == "iob"
                         and port.e_connect
                     ):


### PR DESCRIPTION
Renamed port from `<corename>_cbus_s` to `iob_csrs_cbus_s`. Resolves https://github.com/IObundle/py2hwsw/issues/145