### PR TITLE
Subblocks with 'instantiate = False' don't propagate clk interfaces to top

### DIFF
--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -503,7 +503,7 @@ class iob_core(iob_module, iob_instance):
 
     def __connect_clk_interface(self, port, instantiator):
         """Create, if needed, a clock interface port in instantiator and connect it to self"""
-        if not instantiator.generate_hw:
+        if not instantiator.generate_hw or not self.instantiate:
             return
         _name = f"{port.name}"
         _signals = {k: v for k, v in port.interface.__dict__.items() if k != "widths"}
@@ -565,7 +565,7 @@ class iob_core(iob_module, iob_instance):
                     and not self.is_tester
                 ):
                     self.__connect_memory(port, instantiator)
-                elif(
+                elif (
                     port.interface.type in ["clk_en_rst", "clk_rst"]
                     and instantiator
                     and not self.is_tester


### PR DESCRIPTION
This solves https://github.com/IObundle/py2hwsw/issues/156 and was tested with iob_sync example in iob_uart