### PR TITLE
Subblocks with 'instantiate = False' doesn't bring clk interface to top

### DIFF
--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -503,7 +503,7 @@ class iob_core(iob_module, iob_instance):
 
     def __connect_clk_interface(self, port, instantiator):
         """Create, if needed, a clock interface port in instantiator and connect it to self"""
-        if not instantiator.generate_hw:
+        if not instantiator.generate_hw or not self.instantiate:
             return
         _name = f"{port.name}"
         _signals = {k: v for k, v in port.interface.__dict__.items() if k != "widths"}


### PR DESCRIPTION
Same as https://github.com/IObundle/py2hwsw/pull/158