### PR TITLE
Rename csr script; Fix ipxact; Add `license` attribute.

### DIFF
--- a/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
+++ b/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
@@ -9,7 +9,7 @@ import os
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "scripts"))
 
 import reg_gen
-from iob_csr import create_csr_group
+from csr_classes import create_csr_group
 from interrupts import find_and_update_interrupt_csrs
 from fifos import find_and_update_fifo_csrs
 

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_classes.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_classes.py
@@ -8,29 +8,6 @@ FAIL = "\033[91mError: "  # Red
 ENDC = "\033[0m"  # White
 
 
-def fail_with_msg(msg, exception_type=Exception):
-    """Raise an error with a given message
-    param msg: message to print
-    param exception_type: type of python exception to raise
-    """
-    raise exception_type(FAIL + msg + ENDC)
-
-
-def convert_dict2obj_list(dict_list: dict, obj_class):
-    """Convert a list of dictionaries to a list of objects
-    If list contains elements that are not dictionaries, they are left as is
-    param dict_list: list of dictionaries
-    param obj_class: class of the objects to create
-    """
-    obj_list = []
-    for dict_obj in dict_list:
-        if isinstance(dict_obj, dict):
-            obj_list.append(obj_class(**dict_obj))
-        else:
-            obj_list.append(dict_obj)
-    return obj_list
-
-
 @dataclass
 class iob_csr:
     """Class to represent a Control/Status Register."""
@@ -52,6 +29,29 @@ class iob_csr:
 
         if self.type not in ["R", "W", "RW"]:
             fail_with_msg(f"Invalid CSR type: '{self.type}'", ValueError)
+
+
+def fail_with_msg(msg, exception_type=Exception):
+    """Raise an error with a given message
+    param msg: message to print
+    param exception_type: type of python exception to raise
+    """
+    raise exception_type(FAIL + msg + ENDC)
+
+
+def convert_dict2obj_list(dict_list: dict, obj_class):
+    """Convert a list of dictionaries to a list of objects
+    If list contains elements that are not dictionaries, they are left as is
+    param dict_list: list of dictionaries
+    param obj_class: class of the objects to create
+    """
+    obj_list = []
+    for dict_obj in dict_list:
+        if isinstance(dict_obj, dict):
+            obj_list.append(obj_class(**dict_obj))
+        else:
+            obj_list.append(dict_obj)
+    return obj_list
 
 
 @dataclass

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/reg_gen.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/reg_gen.py
@@ -9,7 +9,7 @@
 import os
 
 import csr_gen
-from iob_csr import iob_csr, iob_csr_group
+from csr_classes import iob_csr, iob_csr_group
 
 
 def find_obj_in_list(obj_list, obj_name, process_func=lambda o: o):

--- a/py2hwsw/lib/iob_system/iob_system.py
+++ b/py2hwsw/lib/iob_system/iob_system.py
@@ -34,7 +34,10 @@ def setup(py_params_dict):
         CPU. This port will give direct access to the system's peripherals. The internal
         memories and crossbar will be removed.""",
         ),
-        "system_attributes": ({}, "Core dictionary with attributes to override/append to the ones of iob_system. Usually passed by child cores to add their own components."),
+        "system_attributes": (
+            {},
+            "Core dictionary with attributes to override/append to the ones of iob_system. Usually passed by child cores to add their own components.",
+        ),
     }
 
     # Converts dictionary tuple values into single values without description

--- a/py2hwsw/lib/peripherals/iob_uart/iob_uart.py
+++ b/py2hwsw/lib/peripherals/iob_uart/iob_uart.py
@@ -10,6 +10,7 @@ def setup(py_params_dict):
         "name": NAME,
         "generate_hw": True,
         "board_list": ["iob_cyclonev_gt_dk", "iob_aes_ku040_db_g"],
+        "description": "The IObundle UART is a RISC-V-based Peripheral written in Verilog, which users can download for free, modify, simulate and implement in FPGA or ASIC. It is written in Verilog and includes a C software driver. The IObundle UART is a very compact IP that works at high clock rates if needed. It supports full-duplex operation and a configurable baud rate. The IObundle UART has a fixed configuration for the Start and Stop bits. More flexible licensable commercial versions are available upon request.",
         "confs": [
             {
                 "name": "DATA_W",

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -41,6 +41,7 @@ from iob_base import (
     add_traceback_msg,
     debug,
 )
+from iob_license import iob_license, update_license
 import sw_tools
 import verilog_format
 import verilog_lint
@@ -193,7 +194,14 @@ class iob_core(iob_module, iob_instance):
             [],
             list,
             get_list_attr_handler(self.create_python_parameter_group),
-            "List of core Python Parameters. Used for documentation.",
+            descr="List of core Python Parameters. Used for documentation.",
+        )
+        self.set_default_attribute(
+            "license",
+            iob_license(),  # Create a default license
+            iob_license,
+            lambda y: update_license(self, **y),
+            descr="License for the core.",
         )
 
         self.attributes_dict = copy.deepcopy(attributes)

--- a/py2hwsw/scripts/iob_license.py
+++ b/py2hwsw/scripts/iob_license.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 IObundle
+#
+# SPDX-License-Identifier: MIT
+
+from dataclasses import dataclass
+from datetime import date
+
+from iob_base import fail_with_msg
+
+
+@dataclass
+class iob_license:
+    """Class that represents a license attribute"""
+
+    # Identifier name for the license.
+    name: str = "MIT"
+    # Year of the license.
+    year: int = date.today().year
+    # Author of the license.
+    author: str = "IObundle"
+
+
+def update_license(core, *args, **kwargs):
+    """Updates existing core license with new attributes
+    param core: core object
+    param kwargs: license arguments
+    """
+    for k, v in kwargs.items():
+        if k not in dir(iob_license):
+            fail_with_msg(f"Unknown license attribute: {k}")
+        setattr(core.license, k, v)

--- a/py2hwsw/scripts/iob_license.py
+++ b/py2hwsw/scripts/iob_license.py
@@ -17,7 +17,7 @@ class iob_license:
     # Year of the license.
     year: int = date.today().year
     # Author of the license.
-    author: str = "IObundle"
+    author: str = "IObundle, Lda"
 
 
 def update_license(core, *args, **kwargs):

--- a/py2hwsw/scripts/ipxact_gen.py
+++ b/py2hwsw/scripts/ipxact_gen.py
@@ -614,14 +614,14 @@ def generate_ipxact_xml(core, dest_dir):
 	<ipxact:description>{core.description}</ipxact:description>
 	{parameters_xml}
 	<ipxact:vendorExtensions>
-		<kactus2:author>IObundle, Lda</kactus2:author>
+		<kactus2:author>{core.license.author}</kactus2:author>
 		<kactus2:version>3,10,15,0</kactus2:version>
 		<kactus2:kts_attributes>
 			<kactus2:kts_productHier>Flat</kactus2:kts_productHier>
 			<kactus2:kts_implementation>HW</kactus2:kts_implementation>
 			<kactus2:kts_firmness>Mutable</kactus2:kts_firmness>
 		</kactus2:kts_attributes>
-		<kactus2:license>{core.license.name} License, Copyright (c) {core.license.year} {core.license.author}</kactus2:license>
+		<kactus2:license>{core.license.name} License, Copyright (c) {core.license.year}</kactus2:license>
 	</ipxact:vendorExtensions>
 </ipxact:component>"""
 

--- a/py2hwsw/scripts/ipxact_gen.py
+++ b/py2hwsw/scripts/ipxact_gen.py
@@ -16,8 +16,8 @@ sys.path.append(
 )
 from iob_csrs import static_reg_tables
 
-# Generates IP-XACT for the given core
 #
+# Generates IP-XACT for the given core
 #
 
 
@@ -621,6 +621,7 @@ def generate_ipxact_xml(core, dest_dir):
 			<kactus2:kts_implementation>HW</kactus2:kts_implementation>
 			<kactus2:kts_firmness>Mutable</kactus2:kts_firmness>
 		</kactus2:kts_attributes>
+		<kactus2:license>{core.license.name} License, Copyright (c) {core.license.year} {core.license.author}</kactus2:license>
 	</ipxact:vendorExtensions>
 </ipxact:component>"""
 

--- a/py2hwsw/scripts/ipxact_gen.py
+++ b/py2hwsw/scripts/ipxact_gen.py
@@ -6,7 +6,6 @@
 
 # TODO: account for log2n_items in the memory map
 import math
-import if_gen
 import re
 import os
 import sys
@@ -122,6 +121,10 @@ class SwRegister:
     ):
         self.name = name
         self.address = address
+
+        if type(hw_size) is str and hw_size.isnumeric():
+            hw_size = int(hw_size)
+
         self.hw_size = hw_size
 
         max_size = hw_size


### PR DESCRIPTION
- Rename 'iob_csr.py' to 'csr_classes.py'. Resolves #173
- Small fix in ipxact_gen.
- Add 'license' attribute to iob_core. Include in IP-XACT. See af1ccf1 for details.