### PR TITLE
feat(ahb): add ahb interface support, axis2ahb with testbench, example ahb-lite ram

### DIFF
--- a/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/simulation/src/iob_axis2ahb_tb.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/simulation/src/iob_axis2ahb_tb.v
@@ -96,7 +96,7 @@ module iob_axis2ahb_tb;
    wire    [                    MEM_ADDR_W-1:0] ahb_addr;
    wire    [                             3-1:0] ahb_burst;
    wire                                         ahb_mastlock;
-   wire    [                             3-1:0] ahb_prot;
+   wire    [                             4-1:0] ahb_prot;
    wire    [                             3-1:0] ahb_size;
    wire    [                             2-1:0] ahb_trans;
    wire    [                        DATA_W-1:0] ahb_wdata;

--- a/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/simulation/src/iob_axis2ahb_tb.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/simulation/src/iob_axis2ahb_tb.v
@@ -71,11 +71,9 @@ module iob_axis2ahb_tb;
    // AXIS2AHB config
 
    // config_in_io
-   //reg     [                    MEM_ADDR_W-1:0] config_in_addr;
    reg                                          config_in_valid;
    wire                                         config_in_ready;
    // config_out_io
-   //reg     [                    MEM_ADDR_W-1:0] config_out_addr;
    reg     [                    MEM_ADDR_W-1:0] config_out_length;
    reg                                          config_out_valid;
    wire                                         config_out_ready;

--- a/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/src/iob_axis2ahb.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/src/iob_axis2ahb.v
@@ -1,0 +1,313 @@
+// SPDX-FileCopyrightText: 2025 IObundle
+//
+// SPDX-License-Identifier: MIT
+
+// Language: Verilog 2001
+`timescale 1ns / 1ps
+`include "iob_axis2ahb_conf.vh"
+
+/*
+ * AXIS to AHB adapter
+ */
+module iob_axis2ahb #(
+   `include "iob_axis2ahb_params.vs"
+) (
+   `include "iob_axis2ahb_io.vs"
+);
+   localparam [2:0] HSIZE = $clog2(DATA_WIDTH / 8);
+   localparam [2:0] BURST_SINGLE = 3'b0, BURST_INCR = 3'b1;
+   localparam [DATA_WIDTH-1:0] ADDR_STEP = DATA_WIDTH / 8;  // byte addressable memory
+
+   localparam STATE_W = 2;
+   localparam [STATE_W-1:0] WAIT_CONFIG = 2'd0, WAIT_DATA = 2'd1;
+   localparam [STATE_W-1:0] TRANSFER = 2'd2, LAST_DATA = 2'd3;
+   localparam [1:0] TRANS_IDLE = 2'd0, TRANS_BUSY = 2'd1, TRANS_NONSEQ = 2'd2, TRANS_SEQ = 2'd3;
+
+   // Constant Outputs
+   // AHB
+   assign m_ahb_mastlock_o = 1'b0;
+   assign m_ahb_prot_o     = 4'b0011;
+   assign m_ahb_size_o     = HSIZE;  // always full data width
+   assign m_ahb_sel_o      = 1'b1;
+   // Managers can perform single transfers using:
+   // undefined length burst (INCR) with length of 1.
+   assign m_ahb_burst_o    = 3'b1;
+
+   // COMPUTE AHB OUTPUTS
+
+   // haddr
+   wire [ADDR_WIDTH-1:0] addr_add_step;
+   assign addr_add_step = m_ahb_addr_o + ADDR_STEP;
+
+   reg [ADDR_WIDTH-1:0] haddr_nxt;
+   iob_reg_cear #(
+      .DATA_W (ADDR_WIDTH),
+      .RST_VAL(0)
+   ) iob_reg_haddr (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .data_i(haddr_nxt),
+      .data_o(m_ahb_addr_o)
+   );
+
+   // htrans
+   reg [2-1:0] htrans_nxt;
+   iob_reg_cear #(
+      .DATA_W (2),
+      .RST_VAL(0)
+   ) iob_reg_htrans (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .data_i(htrans_nxt),
+      .data_o(m_ahb_trans_o)
+   );
+
+   // hwdata
+   reg [DATA_WIDTH-1:0] hwdata_nxt;
+   //wire [DATA_WIDTH-1:0] hwdata_pipe;
+   //iob_reg_cear #(
+   //   .DATA_W (DATA_WIDTH),
+   //   .RST_VAL(0)
+   //) hwdata_pipe_reg (
+   //   .clk_i (clk_i),
+   //   .arst_i(arst_i),
+   //   .cke_i (cke_i),
+   //   .data_i(hwdata_nxt),
+   //   .data_o(hwdata_pipe)
+   //);
+   iob_reg_cear #(
+      .DATA_W (DATA_WIDTH),
+      .RST_VAL(0)
+   ) hwdata_reg (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      //.data_i(hwdata_pipe),
+      .data_i(hwdata_nxt),
+      .data_o(m_ahb_wdata_o)
+   );
+
+   // hwstrb
+   reg  [STRB_WIDTH-1:0] hwstrb_nxt;
+   wire [STRB_WIDTH-1:0] hwstrb_pipe;
+   iob_reg_cear #(
+      .DATA_W (STRB_WIDTH),
+      .RST_VAL(0)
+   ) hwstrb_pipe_reg (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .data_i(hwstrb_nxt),
+      .data_o(hwstrb_pipe)
+   );
+   iob_reg_cear #(
+      .DATA_W (STRB_WIDTH),
+      .RST_VAL(0)
+   ) hwstrb_reg (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .data_i(hwstrb_pipe),
+      .data_o(m_ahb_wstrb_o)
+   );
+
+   // hwrite
+   reg hwrite_nxt;
+   iob_reg_cear #(
+      .DATA_W (1),
+      .RST_VAL(0)
+   ) hwrite_reg (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .data_i(hwrite_nxt),
+      .data_o(m_ahb_write_o)
+   );
+
+   // config registers
+   reg  [ADDR_WIDTH-1:0] config_out_length_nxt;
+   wire [ADDR_WIDTH-1:0] config_out_length_int;
+   iob_reg_cear #(
+      .DATA_W (ADDR_WIDTH),
+      .RST_VAL(0)
+   ) config_out_length_reg (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .data_i(config_out_length_nxt),
+      .data_o(config_out_length_int)
+   );
+
+
+   // state register
+   wire [STATE_W-1:0] state;
+   reg  [STATE_W-1:0] state_nxt;
+   iob_reg_cear #(
+      .DATA_W (STATE_W),
+      .RST_VAL(0)
+   ) state_reg (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .data_i(state_nxt),
+      .data_o(state)
+   );
+
+   reg [DATA_WIDTH-1:0] out_axis_tdata_int;
+   reg                  out_axis_tlast_int;
+
+   reg                  config_in_ready_int;
+   reg                  config_out_ready_int;
+
+   // AXIS OUTPUTS
+   assign out_axis_tdata_o   = out_axis_tdata_int;
+   assign out_axis_tlast_o   = out_axis_tlast_int;
+
+   // axis out tready register
+   reg in_axis_tready_nxt;
+   iob_reg_cear #(
+      .DATA_W (1),
+      .RST_VAL(0)
+   ) in_axis_tready_reg (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .data_i(in_axis_tready_nxt),
+      .data_o(in_axis_tready_o)
+   );
+
+   // axis in tvalid register
+   reg out_axis_tvalid_nxt;
+   iob_reg_cear #(
+      .DATA_W (1),
+      .RST_VAL(0)
+   ) out_axis_tvalid_reg (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .data_i(out_axis_tvalid_nxt),
+      .data_o(out_axis_tvalid_o)
+   );
+
+
+
+   // CONFIG OUTPUTS
+   assign config_in_ready_o  = config_in_ready_int;
+   assign config_out_ready_o = config_out_ready_int;
+
+   // state machine
+   always @* begin
+      state_nxt             = state;
+
+      haddr_nxt             = m_ahb_addr_o;
+      htrans_nxt            = m_ahb_trans_o;
+      hwdata_nxt            = m_ahb_wdata_o;
+      hwstrb_nxt            = hwstrb_pipe;
+      hwrite_nxt            = m_ahb_write_o;
+
+      in_axis_tready_nxt    = 1'b0;
+      out_axis_tdata_int    = 1'b0;
+      out_axis_tvalid_nxt   = 1'b0;
+      out_axis_tlast_int    = 1'b0;
+
+      config_in_ready_int   = 1'b0;
+      config_out_ready_int  = 1'b0;
+      config_out_length_nxt = config_out_length_int;
+
+      case (state)
+         // wait for address/length configuration
+         WAIT_CONFIG: begin
+            hwrite_nxt = 1'b0;
+            hwstrb_nxt = {STRB_WIDTH{1'b0}};
+            // AXIS IN priority
+            if (config_in_valid_i) begin  // write access
+               config_in_ready_int = 1'b1;
+
+               haddr_nxt           = config_in_addr_i;
+               in_axis_tready_nxt  = 1'b1;
+               state_nxt           = WAIT_DATA;
+            end else if (config_out_valid_i) begin  // read access
+               config_out_ready_int  = 1'b1;
+               config_out_length_nxt = config_out_length_i;
+
+               haddr_nxt             = config_out_addr_i;
+               htrans_nxt            = TRANS_NONSEQ;
+               state_nxt             = TRANSFER;
+            end
+         end
+         // wait for data from AXIS (write only)
+         WAIT_DATA: begin
+            //if (m_ahb_write_o) begin
+            in_axis_tready_nxt = 1'b1;
+            if (in_axis_tvalid_i) begin
+               htrans_nxt = TRANS_NONSEQ;
+               hwdata_nxt = in_axis_tdata_i;
+               hwstrb_nxt = {STRB_WIDTH{1'b1}};
+               hwrite_nxt = 1'b1;
+
+               state_nxt  = TRANSFER;
+            end
+            //end
+         end
+         TRANSFER: begin
+            if (m_ahb_write_o & m_ahb_readyout_i) begin  // write access
+               // get next data
+               in_axis_tready_nxt = 1'b1;
+               if (m_ahb_trans_o != TRANS_BUSY) begin
+                  haddr_nxt = addr_add_step;
+               end
+
+               if (in_axis_tvalid_i) begin
+                  htrans_nxt = TRANS_SEQ;
+                  hwdata_nxt = in_axis_tdata_i;
+                  hwstrb_nxt = {STRB_WIDTH{1'b1}};
+
+                  if (in_axis_tlast_i) begin
+                     state_nxt = LAST_DATA;
+                  end
+               end else begin
+                  htrans_nxt = TRANS_BUSY;
+               end
+            end else begin  // read access
+               // wait for hready
+               if (m_ahb_readyout_i) begin
+                  out_axis_tvalid_nxt = 1'b1;
+                  out_axis_tdata_int  = m_ahb_rdata_i;
+
+                  if (m_ahb_trans_o != TRANS_BUSY) begin
+                     haddr_nxt = addr_add_step;
+                  end
+
+                  // busy until AXIS OUT reads data
+                  if (~out_axis_tready_i) begin
+                     htrans_nxt = TRANS_BUSY;
+                  end else if (config_out_length_int == 0) begin
+                     out_axis_tlast_int = 1'b1;
+
+                     htrans_nxt         = TRANS_IDLE;
+                     state_nxt          = WAIT_CONFIG;
+                  end else begin
+                     config_out_length_nxt = config_out_length_int - 1'b1;
+                     htrans_nxt            = TRANS_SEQ;
+                  end
+               end
+            end
+         end
+         // no address and control, last data (write only)
+         LAST_DATA: begin
+            if (m_ahb_write_o & m_ahb_readyout_i) begin
+               htrans_nxt = TRANS_IDLE;
+               hwstrb_nxt = {STRB_WIDTH{1'b0}};
+               hwrite_nxt = 1'b0;
+
+               state_nxt  = WAIT_CONFIG;
+            end
+         end
+         default: begin
+             state_nxt = WAIT_CONFIG;
+         end
+      endcase
+   end
+endmodule

--- a/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/src/iob_axis2ahb.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/src/iob_axis2ahb.v
@@ -66,17 +66,6 @@ module iob_axis2ahb #(
 
    // hwdata
    reg [DATA_WIDTH-1:0] hwdata_nxt;
-   //wire [DATA_WIDTH-1:0] hwdata_pipe;
-   //iob_reg_cear #(
-   //   .DATA_W (DATA_WIDTH),
-   //   .RST_VAL(0)
-   //) hwdata_pipe_reg (
-   //   .clk_i (clk_i),
-   //   .arst_i(arst_i),
-   //   .cke_i (cke_i),
-   //   .data_i(hwdata_nxt),
-   //   .data_o(hwdata_pipe)
-   //);
    iob_reg_cear #(
       .DATA_W (DATA_WIDTH),
       .RST_VAL(0)

--- a/py2hwsw/lib/hardware/buses/iob_axis2ahb/iob_axis2ahb.py
+++ b/py2hwsw/lib/hardware/buses/iob_axis2ahb/iob_axis2ahb.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2025 IObundle
+#
+# SPDX-License-Identifier: MIT
+
+
+def setup(py_params_dict):
+    attributes_dict = {
+        "generate_hw": False,
+        "confs": [
+            {
+                "name": "ADDR_WIDTH",
+                "descr": "Width of address bus in bits",
+                "type": "P",
+                "val": "32",
+                "min": "1",
+                "max": "32",
+            },
+            {
+                "name": "DATA_WIDTH",
+                "descr": "Width of input (subordinate/manager) AXIS/AHB interface data bus in bits",
+                "type": "P",
+                "val": "32",
+                "min": "1",
+                "max": "32",
+            },
+            {
+                "name": "STRB_WIDTH",
+                "descr": "Width of input (subordinate/manager) AXIS/AHB interface wstrb (width of data bus in words)",
+                "type": "P",
+                "val": "(DATA_WIDTH / 8)",
+                "min": "1",
+                "max": "32",
+            },
+            {
+                "name": "AXI_ID_WIDTH",
+                "descr": "Width of AXI ID signal",
+                "type": "P",
+                "val": "8",
+                "min": "1",
+                "max": "32",
+            },
+        ],
+        "ports": [
+            {
+                "name": "clk_en_rst_s",
+                "signals": {
+                    "type": "iob_clk",
+                },
+                "descr": "Clock, clock enable and reset",
+            },
+            {
+                "name": "axis_s",
+                "descr": "AXIS IN interface",
+                "signals": {
+                    "type": "axis",
+                    "prefix": "in_",
+                    "ADDR_W": "ADDR_WIDTH",
+                    "DATA_W": "DATA_WIDTH",
+                },
+            },
+            {
+                "name": "axis_m",
+                "descr": "AXIS OUT interface",
+                "signals": {
+                    "type": "axis",
+                    "prefix": "out_",
+                    "ADDR_W": "ADDR_WIDTH",
+                    "DATA_W": "DATA_WIDTH",
+                },
+            },
+            {
+                "name": "config_in_io",
+                "descr": "AXI Stream input configuration interface",
+                "signals": [
+                    {
+                        "name": "config_in_addr_i",
+                        "width": "ADDR_WIDTH",
+                        "descr": "",
+                    },
+                    {
+                        "name": "config_in_valid_i",
+                        "width": 1,
+                        "descr": "",
+                    },
+                    {
+                        "name": "config_in_ready_o",
+                        "width": 1,
+                        "descr": "",
+                    },
+                ],
+            },
+            {
+                "name": "config_out_io",
+                "descr": "AXI Stream output configuration interface",
+                "signals": [
+                    {
+                        "name": "config_out_addr_i",
+                        "width": "ADDR_WIDTH",
+                        "descr": "",
+                    },
+                    {
+                        "name": "config_out_length_i",
+                        "width": "ADDR_WIDTH",
+                        "descr": "",
+                    },
+                    {
+                        "name": "config_out_valid_i",
+                        "width": 1,
+                        "descr": "",
+                    },
+                    {
+                        "name": "config_out_ready_o",
+                        "width": 1,
+                        "descr": "",
+                    },
+                ],
+            },
+            {
+                "name": "ahb_m",
+                "descr": "Manager AHB interface",
+                "signals": {
+                    "type": "ahb",
+                    "prefix": "m_",
+                    "ADDR_W": "ADDR_WIDTH",
+                    "DATA_W": "DATA_WIDTH",
+                },
+            },
+        ],
+        "subblocks": [
+            {
+                "core_name": "iob_reg",
+                "instantiate": False,
+            },
+        ],
+        "superblocks": [
+            {"core_name": "iob_axistream_in"},
+            {"core_name": "iob_axistream_out"},
+            {"core_name": "iob_ahb_ram"},
+        ],
+    }
+
+    return attributes_dict

--- a/py2hwsw/lib/hardware/memories/iob_ahb_ram/hardware/src/AHB2MEM.v
+++ b/py2hwsw/lib/hardware/memories/iob_ahb_ram/hardware/src/AHB2MEM.v
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2024 Lovekumar2
+// SPDX-FileCopyrightText: 2025 IObundle
+//
+// SPDX-License-Identifier: MIT
+
+`timescale 1ns / 1ps
+
+//
+//  --========================================================================--
+//  Source: github.com/Lovekumar2
+//  - Repository: Design-a-Single-Port-RAM-256x32-with-synchronous-Read-Write-By-using-AHB-lite-Bus-Interface
+//  --========================================================================--
+//  Version and Release Control Information:
+//
+//  File Name           : AHB2MEM.v
+//  File Revision       : 1.60
+//
+//  ----------------------------------------------------------------------------
+//  Purpose             : Basic AHBLITE Internal Memory Default Size = 16KB
+//                        
+//  --========================================================================--
+module AHB2MEM #(
+   parameter MEMWIDTH = 14
+)  // SIZE[Bytes] = 2 ^ MEMWIDTH[Bytes] = 2 ^ MEMWIDTH / 4[Entries]
+(
+   //AHBLITE INTERFACE
+   //Subordinate Select Signals
+   input wire                HSEL,
+   //Global Signal
+   input wire                HCLK,
+   input wire                HRESETn,
+   //Address, Control & Write Data
+   input wire                HREADY,
+   input wire [MEMWIDTH-1:0] HADDR,
+   input wire [         1:0] HTRANS,
+   input wire                HWRITE,
+   input wire [         2:0] HSIZE,
+
+   input  wire [31:0] HWDATA,
+   // Transfer Response & Read Data
+   output wire        HREADYOUT,
+   output reg  [31:0] HRDATA
+);
+
+   assign HREADYOUT = 1'b1;  // Always ready
+
+   // Memory Array
+   reg [31:0] memory        [0:(2**(MEMWIDTH-2)-1)];
+
+   // initial
+   // begin
+   //   $readmemh("C:/Users/lovek/Desktop/arm keil hex file/sigleportram.hex", memory);
+   // end
+
+   // Registers to store Adress Phase Signals
+   reg        APhase_HSEL;
+   reg        APhase_HWRITE;
+   reg [ 1:0] APhase_HTRANS;
+   //reg [31:0] APhase_HRADDR;
+   reg [31:0] APhase_HWADDR;
+   reg [ 2:0] APhase_HSIZE;
+
+   // Sample the Address Phase   
+   always @(posedge HCLK or negedge HRESETn) begin
+      if (!HRESETn) begin
+         APhase_HSEL   <= 1'b0;
+         APhase_HWRITE <= 1'b0;
+         APhase_HTRANS <= 2'b00;
+         APhase_HWADDR <= 32'h0;
+         APhase_HSIZE  <= 3'b000;
+         //APhase_HRADDR <= 32'h0;
+      end else if (HREADY) begin
+         APhase_HSEL   <= HSEL;
+         APhase_HWRITE <= HWRITE;
+         APhase_HTRANS <= HTRANS;
+         APhase_HWADDR <= HADDR;
+         APhase_HSIZE  <= HSIZE;
+         //APhase_HRADDR[MEMWIDTH-1-2:0] <= HADDR[MEMWIDTH-1:2];
+      end
+   end
+
+   // Decode the bytes lanes depending on HSIZE & HADDR[1:0]
+
+   wire tx_byte = ~APhase_HSIZE[1] & ~APhase_HSIZE[0];
+   wire tx_half = ~APhase_HSIZE[1] & APhase_HSIZE[0];
+   wire tx_word = APhase_HSIZE[1];
+
+   wire byte_at_00 = tx_byte & ~APhase_HWADDR[1] & ~APhase_HWADDR[0];
+   wire byte_at_01 = tx_byte & ~APhase_HWADDR[1] & APhase_HWADDR[0];
+   wire byte_at_10 = tx_byte & APhase_HWADDR[1] & ~APhase_HWADDR[0];
+   wire byte_at_11 = tx_byte & APhase_HWADDR[1] & APhase_HWADDR[0];
+
+   wire half_at_00 = tx_half & ~APhase_HWADDR[1];
+   wire half_at_10 = tx_half & APhase_HWADDR[1];
+
+   wire word_at_00 = tx_word;
+
+   wire byte0 = word_at_00 | half_at_00 | byte_at_00;
+   wire byte1 = word_at_00 | half_at_00 | byte_at_01;
+   wire byte2 = word_at_00 | half_at_10 | byte_at_10;
+   wire byte3 = word_at_00 | half_at_10 | byte_at_11;
+
+   always @(posedge HCLK) begin
+      if (APhase_HSEL & APhase_HWRITE & APhase_HTRANS[1]) begin
+         if (byte0) memory[APhase_HWADDR[MEMWIDTH-1:2]][7:0] <= HWDATA[7:0];
+         if (byte1) memory[APhase_HWADDR[MEMWIDTH-1:2]][15:8] <= HWDATA[15:8];
+         if (byte2) memory[APhase_HWADDR[MEMWIDTH-1:2]][23:16] <= HWDATA[23:16];
+         if (byte3) memory[APhase_HWADDR[MEMWIDTH-1:2]][31:24] <= HWDATA[31:24];
+      end
+
+      HRDATA = memory[HADDR[MEMWIDTH-1:2]];
+   end
+
+endmodule

--- a/py2hwsw/lib/hardware/memories/iob_ahb_ram/hardware/src/AHB2MEM.v
+++ b/py2hwsw/lib/hardware/memories/iob_ahb_ram/hardware/src/AHB2MEM.v
@@ -47,11 +47,6 @@ module AHB2MEM #(
    // Memory Array
    reg [31:0] memory        [0:(2**(MEMWIDTH-2)-1)];
 
-   // initial
-   // begin
-   //   $readmemh("C:/Users/lovek/Desktop/arm keil hex file/sigleportram.hex", memory);
-   // end
-
    // Registers to store Adress Phase Signals
    reg        APhase_HSEL;
    reg        APhase_HWRITE;

--- a/py2hwsw/lib/hardware/memories/iob_ahb_ram/iob_ahb_ram.py
+++ b/py2hwsw/lib/hardware/memories/iob_ahb_ram/iob_ahb_ram.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2025 IObundle
+#
+# SPDX-License-Identifier: MIT
+
+
+def setup(py_params_dict):
+    attributes_dict = {
+        "generate_hw": True,
+        "confs": [
+            {
+                "name": "ADDR_WIDTH",
+                "descr": "",
+                "type": "P",
+                "val": "14",
+                "min": "1",
+                "max": "32",
+            },
+            {
+                "name": "DATA_WIDTH",
+                "descr": "",
+                "type": "P",
+                "val": "32",
+                "min": "1",
+                "max": "32",
+            },
+        ],
+        "ports": [
+            {
+                "name": "clk_en_rst_s",
+                "signals": {
+                    "type": "iob_clk",
+                    "params": "arstn",
+                },
+                "descr": "Clock, clock enable and reset",
+            },
+            {
+                "name": "ahb_s",
+                "descr": "Subordinate AHB interface",
+                "signals": {
+                    "type": "ahb",
+                    "prefix": "s_",
+                    "ADDR_W": "ADDR_WIDTH",
+                    "DATA_W": "DATA_WIDTH",
+                },
+            },
+        ],
+        "snippets": [
+            {
+                "verilog_code": """
+   AHB2MEM #(
+      .MEMWIDTH(ADDR_WIDTH)
+   ) ahb2bram_inst (
+      // Subordinate Select Signals
+      .HSEL     (s_ahb_sel_i),
+      // Global Signals
+      .HCLK     (clk_i),
+      .HRESETn  (arst_n_i),
+      // Address, Control & Write Data
+      .HREADY   (1'b1),
+      .HADDR    (s_ahb_addr_i),
+      .HTRANS   (s_ahb_trans_i),
+      .HWRITE   (s_ahb_write_i),
+      .HSIZE    (s_ahb_size_i),
+      .HWDATA   (s_ahb_wdata_i),
+      // Transfer Response & Read Data
+      .HREADYOUT(s_ahb_readyout_o),
+      .HRDATA   (s_ahb_rdata_o)
+   );
+
+    // Transfer Response always okay
+    assign s_ahb_resp_o = 1'b0;
+
+""",
+            },
+        ],
+    }
+
+    return attributes_dict

--- a/py2hwsw/py2hwsw_document/document/tsrc/if_gen.tex
+++ b/py2hwsw/py2hwsw_document/document/tsrc/if_gen.tex
@@ -119,7 +119,7 @@ For example, to add an AXI port to a core, add the following python dictionary t
 	"name": "example_port_m",
 	"descr": "AXI manager port",
 	"signals": {
-		"type": "axil",
+		"type": "axi",
 		"ADDR_W": 32,
 		"DATA_W": 32,
 		"PROT_W": 3,
@@ -192,7 +192,7 @@ For example, to add an AHB port to a core, add the following python dictionary t
 	"name": "example_port_m",
 	"descr": "AHB manager port",
 	"signals": {
-		"type": "axil",
+		"type": "ahb",
 		"ADDR_W": 32,
 		"DATA_W": 32,
 		"BURST_W": 3,

--- a/py2hwsw/scripts/if_gen.py
+++ b/py2hwsw/scripts/if_gen.py
@@ -907,9 +907,6 @@ def get_apb_ports():
 #
 # AHB
 #
-# ADDR_W = 32
-# DATA_W = 32
-# SIZE_W = 3
 AHB_PROT_W = 4
 AHB_BURST_W = 3
 AHB_TRANS_W = 2

--- a/py2hwsw/scripts/if_gen.py
+++ b/py2hwsw/scripts/if_gen.py
@@ -909,10 +909,10 @@ def get_apb_ports():
 #
 # ADDR_W = 32
 # DATA_W = 32
-# BURST_W = 3
-# PROT_W = 4
 # SIZE_W = 3
-TRANS_W = 2
+AHB_PROT_W = 4
+AHB_BURST_W = 3
+AHB_TRANS_W = 2
 
 
 @parse_widths
@@ -925,7 +925,7 @@ def get_ahb_ports():
         ),
         iob_signal(
             name="ahb_burst_o",
-            width=BURST_W,
+            width=AHB_BURST_W,
             descr="Burst size.",
         ),
         iob_signal(
@@ -935,7 +935,7 @@ def get_ahb_ports():
         ),
         iob_signal(
             name="ahb_prot_o",
-            width=PROT_W,
+            width=AHB_PROT_W,
             descr="Byte address of the transfer.",
         ),
         iob_signal(
@@ -945,7 +945,7 @@ def get_ahb_ports():
         ),
         iob_signal(
             name="ahb_trans_o",
-            width=TRANS_W,
+            width=AHB_TRANS_W,
             descr="Transfer type.",
         ),
         iob_signal(


### PR DESCRIPTION
- add AHB interface support
- axis2ahb converter with testbench, check with:
```bash
cd py2hwsw/lib;
nix-shell --run "make sim-run CORE=iob_axis2ahb"
```
- example ahb-lite ram