### PR TITLE
fix(ahb): use resp signal, add busy to converter

### DIFF
--- a/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/simulation/src/iob_axis2ahb_tb.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/simulation/src/iob_axis2ahb_tb.v
@@ -295,6 +295,8 @@ module iob_axis2ahb_tb;
       .config_out_length_i(config_out_length),
       .config_out_valid_i (config_out_valid),
       .config_out_ready_o (config_out_ready),
+      // General io
+      .busy_o             (),
       // ahb_m
       .m_ahb_addr_o       (ahb_addr),
       .m_ahb_burst_o      (ahb_burst),

--- a/py2hwsw/lib/hardware/buses/iob_axis2ahb/iob_axis2ahb.py
+++ b/py2hwsw/lib/hardware/buses/iob_axis2ahb/iob_axis2ahb.py
@@ -116,6 +116,17 @@ def setup(py_params_dict):
                 ],
             },
             {
+                "name": "general_o",
+                "descr": "Generic interface",
+                "signals": [
+                    {
+                        "name": "busy_o",
+                        "width": 1,
+                        "descr": "Module busy: (0) waiting for configuration; (1) during operation.",
+                    },
+                ],
+            },
+            {
                 "name": "ahb_m",
                 "descr": "Manager AHB interface",
                 "signals": {


### PR DESCRIPTION
- use resp signal to detect ERROR in accesses
- add busy output to axis2ahb to check for state:
    - can also be used to detect terminated transfers before expected (without tlast)