### PR TITLE
Update iob_reg names to care suffixes; Move connection verification to iob_port; Ports can be connected to constant values

### DIFF
--- a/py2hwsw/lib/hardware/amd/iob_xilinx_axi_interconnect/iob_xilinx_axi_interconnect.py
+++ b/py2hwsw/lib/hardware/amd/iob_xilinx_axi_interconnect/iob_xilinx_axi_interconnect.py
@@ -63,7 +63,7 @@ def setup(py_params_dict):
                 "descr": "Clock and reset inputs",
                 "signals": {
                     "type": "iob_clk",
-                    "params": "arst",
+                    "params": "a",
                 },
             },
         ],

--- a/py2hwsw/lib/hardware/arith_logic/accumulators/iob_acc/iob_acc.py
+++ b/py2hwsw/lib/hardware/arith_logic/accumulators/iob_acc/iob_acc.py
@@ -116,7 +116,7 @@ def setup(py_params_dict):
                     "RST_VAL": "RST_VAL",
                 },
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
                 "connect": {
                     "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/arith_logic/accumulators/iob_acc_ld/iob_acc_ld.py
+++ b/py2hwsw/lib/hardware/arith_logic/accumulators/iob_acc_ld/iob_acc_ld.py
@@ -125,7 +125,7 @@ def setup(py_params_dict):
                     "RST_VAL": "RST_VAL",
                 },
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
                 "connect": {
                     "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/arith_logic/counter/iob_counter/iob_counter.py
+++ b/py2hwsw/lib/hardware/arith_logic/counter/iob_counter/iob_counter.py
@@ -74,7 +74,7 @@ def setup(py_params_dict):
                     "RST_VAL": "RST_VAL",
                 },
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
                 "connect": {
                     "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/arith_logic/counter/iob_counter_ld/iob_counter_ld.py
+++ b/py2hwsw/lib/hardware/arith_logic/counter/iob_counter_ld/iob_counter_ld.py
@@ -88,7 +88,7 @@ def setup(py_params_dict):
                     "RST_VAL": "RST_VAL",
                 },
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
                 "connect": {
                     "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/arith_logic/counter/iob_modcnt/iob_modcnt.py
+++ b/py2hwsw/lib/hardware/arith_logic/counter/iob_modcnt/iob_modcnt.py
@@ -88,7 +88,7 @@ def setup(py_params_dict):
                     "RST_VAL": "RST_VAL",
                 },
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
                 "connect": {
                     "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/arith_logic/iob_diff/hardware/src/iob_diff.v
+++ b/py2hwsw/lib/hardware/arith_logic/iob_diff/hardware/src/iob_diff.v
@@ -17,7 +17,7 @@ module iob_diff #(
 );
 
   wire [DATA_W-1:0] data_i_reg;
-  iob_reg_cear_r #(DATA_W, RST_VAL) reg0 (
+  iob_reg_car #(DATA_W, RST_VAL) reg0 (
       `include "iob_diff_iob_clk_s_s_portmap.vs"
 
       .rst_i(rst_i),

--- a/py2hwsw/lib/hardware/arith_logic/iob_diff/iob_diff.py
+++ b/py2hwsw/lib/hardware/arith_logic/iob_diff/iob_diff.py
@@ -11,7 +11,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_r_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst",
+                    "clk_en_rst_s": "c_a_r",
                 },
             },
         ],

--- a/py2hwsw/lib/hardware/arith_logic/iob_edge_detect/hardware/src/iob_edge_detect.v
+++ b/py2hwsw/lib/hardware/arith_logic/iob_edge_detect/hardware/src/iob_edge_detect.v
@@ -19,7 +19,7 @@ module iob_edge_detect #(
   generate
     if (EDGE_TYPE == "falling") begin : gen_falling
       assign bit_int = ~bit_i;
-      iob_reg_cear_r #(
+      iob_reg_car #(
           .DATA_W (1),
           .RST_VAL(1'b0)
       ) bit_reg (
@@ -32,7 +32,7 @@ module iob_edge_detect #(
     end else begin : gen_default_rising
       assign bit_int = bit_i;
 
-      iob_reg_cear_r #(
+      iob_reg_car #(
           .DATA_W (1),
           .RST_VAL(1'b1)
       ) bit_reg (
@@ -49,7 +49,7 @@ module iob_edge_detect #(
       assign detected_o = bit_int & ~bit_int_q;
     end else begin : gen_step
       wire detected_prev;
-      iob_reg_cear_r #(
+      iob_reg_car #(
           .DATA_W(1)
       ) detected_reg (
           `include "iob_edge_detect_iob_clk_s_s_portmap.vs"

--- a/py2hwsw/lib/hardware/arith_logic/iob_edge_detect/iob_edge_detect.py
+++ b/py2hwsw/lib/hardware/arith_logic/iob_edge_detect/iob_edge_detect.py
@@ -41,7 +41,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_r_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst",
+                    "clk_en_rst_s": "c_a_r",
                 },
             },
         ],

--- a/py2hwsw/lib/hardware/buses/iob_apb2iob/hardware/src/iob_apb2iob.v
+++ b/py2hwsw/lib/hardware/buses/iob_apb2iob/hardware/src/iob_apb2iob.v
@@ -36,7 +36,7 @@ module iob_apb2iob #(
    //program counter
    wire [1:0] pc_cnt;
    reg  [1:0] pc_cnt_nxt;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (2),
       .RST_VAL(2'd0)
    ) pc_reg (
@@ -86,7 +86,7 @@ module iob_apb2iob #(
 
 
    //APB outputs
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) apb_ready_reg (
@@ -95,7 +95,7 @@ module iob_apb2iob #(
       .data_o(apb_ready_o)
    );
 
-   iob_reg_cear_e #(
+   iob_reg_cae #(
       .DATA_W (DATA_W),
       .RST_VAL({DATA_W{1'd0}})
    ) apb_rdata_reg (

--- a/py2hwsw/lib/hardware/buses/iob_apb2iob/iob_apb2iob.py
+++ b/py2hwsw/lib/hardware/buses/iob_apb2iob/iob_apb2iob.py
@@ -38,7 +38,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_e_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_en",
+                    "clk_en_rst_s": "c_a_e",
                 },
             },
         ],

--- a/py2hwsw/lib/hardware/buses/iob_asym_converter/hardware/src/iob_asym_converter.v
+++ b/py2hwsw/lib/hardware/buses/iob_asym_converter/hardware/src/iob_asym_converter.v
@@ -24,7 +24,7 @@ module iob_asym_converter #(
 
    //Data is valid after read enable
    wire r_data_valid_reg;
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'b0)
    ) r_data_valid_reg_inst (
@@ -36,7 +36,7 @@ module iob_asym_converter #(
 
    //Register read data from the memory
    wire [MAXDATA_W-1:0] r_data_reg;
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (MAXDATA_W),
       .RST_VAL({MAXDATA_W{1'd0}})
    ) r_data_reg_inst (
@@ -66,7 +66,7 @@ module iob_asym_converter #(
 
          //register to hold the LSBs of r_addr
          wire [$clog2(R)-1:0] r_addr_lsbs_reg;
-         iob_reg_cear_e #(
+         iob_reg_cae #(
             .DATA_W ($clog2(R)),
             .RST_VAL({$clog2(R) {1'd0}})
          ) r_addr_reg_inst (

--- a/py2hwsw/lib/hardware/buses/iob_asym_converter/iob_asym_converter.py
+++ b/py2hwsw/lib/hardware/buses/iob_asym_converter/iob_asym_converter.py
@@ -111,14 +111,14 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_r_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst",
+                    "clk_en_rst_s": "c_a_r",
                 },
             },
             {
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_re_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
             {

--- a/py2hwsw/lib/hardware/buses/iob_axi2iob/hardware/src/iob_axi2iob.v
+++ b/py2hwsw/lib/hardware/buses/iob_axi2iob/hardware/src/iob_axi2iob.v
@@ -149,7 +149,7 @@ module iob_axi2iob #(
    assign iob_wstrb_o = m_axil_arvalid ? {STRB_WIDTH{1'b0}} : m_axil_wstrb;
    assign iob_rready_o = 1'b1;
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (ADDR_WIDTH),
       .RST_VAL({ADDR_WIDTH{1'b0}})
    ) iob_reg_awaddr (
@@ -162,7 +162,7 @@ module iob_axi2iob #(
       .data_o(m_axil_awaddr_q)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (1),
       .RST_VAL(1'b0)
    ) iob_reg_rvalid (
@@ -175,7 +175,7 @@ module iob_axi2iob #(
       .data_o(iob_rvalid_q)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (DATA_WIDTH),
       .RST_VAL({DATA_WIDTH{1'b0}})
    ) iob_reg_rdata (
@@ -188,7 +188,7 @@ module iob_axi2iob #(
       .data_o(iob_rdata_q)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (1),
       .RST_VAL(1'b0)
    ) iob_reg_bvalid (

--- a/py2hwsw/lib/hardware/buses/iob_axi2iob/iob_axi2iob.py
+++ b/py2hwsw/lib/hardware/buses/iob_axi2iob/iob_axi2iob.py
@@ -73,7 +73,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_re_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
         ],

--- a/py2hwsw/lib/hardware/buses/iob_axi_merge/iob_axi_merge.py
+++ b/py2hwsw/lib/hardware/buses/iob_axi_merge/iob_axi_merge.py
@@ -486,7 +486,7 @@ def setup(py_params_dict):
                 "RST_VAL": "1'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -508,7 +508,7 @@ def setup(py_params_dict):
                 "RST_VAL": "1'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -530,7 +530,7 @@ def setup(py_params_dict):
                 "RST_VAL": f"{NBITS}'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst",
+                "clk_en_rst_s": "c_a_r",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -564,7 +564,7 @@ def setup(py_params_dict):
                 "RST_VAL": "1'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -586,7 +586,7 @@ def setup(py_params_dict):
                 "RST_VAL": "1'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -608,7 +608,7 @@ def setup(py_params_dict):
                 "RST_VAL": "1'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -630,7 +630,7 @@ def setup(py_params_dict):
                 "RST_VAL": f"{NBITS}'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst",
+                "clk_en_rst_s": "c_a_r",
             },
             "connect": {
                 "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/buses/iob_axi_split/iob_axi_split.py
+++ b/py2hwsw/lib/hardware/buses/iob_axi_split/iob_axi_split.py
@@ -403,7 +403,7 @@ def setup(py_params_dict):
                 "RST_VAL": "1'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -425,7 +425,7 @@ def setup(py_params_dict):
                 "RST_VAL": f"{NBITS}'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst",
+                "clk_en_rst_s": "c_a_r",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -447,7 +447,7 @@ def setup(py_params_dict):
                 "RST_VAL": "1'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -469,7 +469,7 @@ def setup(py_params_dict):
                 "RST_VAL": "1'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -491,7 +491,7 @@ def setup(py_params_dict):
                 "RST_VAL": f"{NBITS}'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst",
+                "clk_en_rst_s": "c_a_r",
             },
             "connect": {
                 "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/buses/iob_axil2iob/hardware/src/iob_axil2iob.v
+++ b/py2hwsw/lib/hardware/buses/iob_axil2iob/hardware/src/iob_axil2iob.v
@@ -54,7 +54,7 @@ module iob_axil2iob #(
 
    assign iob_addr_en = axil_arvalid_i | axil_awvalid_i;
 
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (1),
       .RST_VAL(0)
    ) iob_reg_bvalid (
@@ -65,7 +65,7 @@ module iob_axil2iob #(
       .data_o(axil_bvalid_o)
    );
 
-   iob_reg_cear_e #(
+   iob_reg_cae #(
       .DATA_W (ADDR_W),
       .RST_VAL(0)
    ) iob_reg_addr (
@@ -85,7 +85,7 @@ module iob_axil2iob #(
    // axil_awready == 1: waiting for awvalid
    assign awready_en = axil_awready_o ? axil_awvalid_i : (axil_bvalid_o & axil_bready_i);
    assign axil_awready_nxt = ~axil_awready_o; // toggle state
-   iob_reg_cear_e #(
+   iob_reg_cae #(
       .DATA_W (1),
       .RST_VAL(1)
    ) iob_reg_awready (

--- a/py2hwsw/lib/hardware/buses/iob_axil2iob/iob_axil2iob.py
+++ b/py2hwsw/lib/hardware/buses/iob_axil2iob/iob_axil2iob.py
@@ -38,7 +38,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_e_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_en",
+                    "clk_en_rst_s": "c_a_e",
                 },
             },
         ],

--- a/py2hwsw/lib/hardware/buses/iob_axil_split/iob_axil_split.py
+++ b/py2hwsw/lib/hardware/buses/iob_axil_split/iob_axil_split.py
@@ -238,7 +238,7 @@ def setup(py_params_dict):
                 "RST_VAL": f"{NBITS}'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -261,7 +261,7 @@ def setup(py_params_dict):
                 "RST_VAL": f"{NBITS}'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/src/iob_axis2ahb.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2ahb/hardware/src/iob_axis2ahb.v
@@ -44,7 +44,7 @@ module iob_axis2ahb #(
    assign addr_add_step = m_ahb_addr_o + ADDR_STEP;
 
    reg [ADDR_WIDTH-1:0] haddr_nxt;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (ADDR_WIDTH),
       .RST_VAL(0)
    ) iob_reg_haddr (
@@ -57,7 +57,7 @@ module iob_axis2ahb #(
 
    // htrans
    reg [2-1:0] htrans_nxt;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (2),
       .RST_VAL(0)
    ) iob_reg_htrans (
@@ -70,7 +70,7 @@ module iob_axis2ahb #(
 
    // hwdata
    reg [DATA_WIDTH-1:0] hwdata_nxt;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (DATA_WIDTH),
       .RST_VAL(0)
    ) hwdata_reg (
@@ -85,7 +85,7 @@ module iob_axis2ahb #(
    // hwstrb
    reg  [STRB_WIDTH-1:0] hwstrb_nxt;
    wire [STRB_WIDTH-1:0] hwstrb_pipe;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (STRB_WIDTH),
       .RST_VAL(0)
    ) hwstrb_pipe_reg (
@@ -95,7 +95,7 @@ module iob_axis2ahb #(
       .data_i(hwstrb_nxt),
       .data_o(hwstrb_pipe)
    );
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (STRB_WIDTH),
       .RST_VAL(0)
    ) hwstrb_reg (
@@ -108,7 +108,7 @@ module iob_axis2ahb #(
 
    // hwrite
    reg hwrite_nxt;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (1),
       .RST_VAL(0)
    ) hwrite_reg (
@@ -122,7 +122,7 @@ module iob_axis2ahb #(
    // config registers
    reg  [ADDR_WIDTH-1:0] config_out_length_nxt;
    wire [ADDR_WIDTH-1:0] config_out_length_int;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (ADDR_WIDTH),
       .RST_VAL(0)
    ) config_out_length_reg (
@@ -137,7 +137,7 @@ module iob_axis2ahb #(
    // state register
    wire [STATE_W-1:0] state;
    reg  [STATE_W-1:0] state_nxt;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (STATE_W),
       .RST_VAL(0)
    ) state_reg (
@@ -160,7 +160,7 @@ module iob_axis2ahb #(
 
    // axis out tready register
    reg in_axis_tready_nxt;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (1),
       .RST_VAL(0)
    ) in_axis_tready_reg (
@@ -173,7 +173,7 @@ module iob_axis2ahb #(
 
    // axis in tvalid register
    reg out_axis_tvalid_nxt;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (1),
       .RST_VAL(0)
    ) out_axis_tvalid_reg (

--- a/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_rd/hardware/src/iob_axis2axi_rd.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_rd/hardware/src/iob_axis2axi_rd.v
@@ -140,7 +140,7 @@ module iob_axis2axi_rd #(
       endcase
    end
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) r_state_reg (
@@ -152,7 +152,7 @@ module iob_axis2axi_rd #(
       .data_o(r_state)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (RLEN_W),
       .RST_VAL({RLEN_W{1'b0}})
    ) r_length_reg (
@@ -164,7 +164,7 @@ module iob_axis2axi_rd #(
       .data_o(r_remaining_data_o)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (AXI_ADDR_W),
       .RST_VAL({AXI_ADDR_W{1'b0}})
    ) r_addr_reg (

--- a/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_rd/hardware/src/iob_axis2axi_rd_int.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_rd/hardware/src/iob_axis2axi_rd_int.v
@@ -127,7 +127,7 @@ module iob_axis2axi_rd_int #(
       endcase
    end
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W ((AXI_LEN_W + 1)),
       .RST_VAL(0)
    ) length_reg (
@@ -139,7 +139,7 @@ module iob_axis2axi_rd_int #(
       .data_o(length)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (2),
       .RST_VAL(0)
    ) state_reg (
@@ -152,7 +152,7 @@ module iob_axis2axi_rd_int #(
    );
 
    // AXI interface registers
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (AXI_LEN_W),
       .RST_VAL(0)
    ) axi_arlen_reg (
@@ -164,7 +164,7 @@ module iob_axis2axi_rd_int #(
       .data_o(axi_arlen_o)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (AXI_ADDR_W),
       .RST_VAL(0)
    ) axi_araddr_reg (
@@ -176,7 +176,7 @@ module iob_axis2axi_rd_int #(
       .data_o(axi_araddr_o)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(0)
    ) axi_arvalid_reg (
@@ -188,7 +188,7 @@ module iob_axis2axi_rd_int #(
       .data_o(axi_arvalid_o)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(0)
    ) axi_rready_reg (
@@ -200,7 +200,7 @@ module iob_axis2axi_rd_int #(
       .data_o(axi_rready_o)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (AXI_DATA_W),
       .RST_VAL(0)
    ) axi_rdata_reg_inst (
@@ -213,7 +213,7 @@ module iob_axis2axi_rd_int #(
       .data_o(axi_rdata_reg)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (1),
       .RST_VAL(0)
    ) axi_rvalid_reg_inst (

--- a/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_rd/iob_axis2axi_rd.py
+++ b/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_rd/iob_axis2axi_rd.py
@@ -112,11 +112,8 @@ def setup(py_params_dict):
         "subblocks": [
             {"core_name": "iob_fifo2axis"},
             {"core_name": "iob_fifo_sync"},
-            {"core_name": "iob_reg", "port_params": {"clk_en_rst_s": "cke_arst_rst"}},
-            {
-                "core_name": "iob_reg",
-                "port_params": {"clk_en_rst_s": "cke_arst_rst_en"},
-            },
+            {"core_name": "iob_reg", "port_params": {"clk_en_rst_s": "c_a_r"}},
+            {"core_name": "iob_reg", "port_params": {"clk_en_rst_s": "c_a_r_e"}},
         ],
     }
     return attributes_dict

--- a/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_wr/hardware/src/iob_axis2axi_wr.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_wr/hardware/src/iob_axis2axi_wr.v
@@ -141,7 +141,7 @@ module iob_axis2axi_wr #(
    end
 
    // State register
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) w_state_reg (
@@ -154,7 +154,7 @@ module iob_axis2axi_wr #(
    );
 
    // Length registers
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (WLEN_W),
       .RST_VAL({WLEN_W{1'b0}})
    ) w_length_reg (
@@ -167,7 +167,7 @@ module iob_axis2axi_wr #(
    );
 
    // Address registers
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (AXI_ADDR_W),
       .RST_VAL({AXI_ADDR_W{1'b0}})
    ) w_addr_reg (

--- a/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_wr/hardware/src/iob_axis2axi_wr_int.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_wr/hardware/src/iob_axis2axi_wr_int.v
@@ -184,7 +184,7 @@ module iob_axis2axi_wr_int #(
    end
 
    // Registers for address_done and data_done
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) address_done_reg (
@@ -196,7 +196,7 @@ module iob_axis2axi_wr_int #(
       .data_o(address_done)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) data_done_reg (
@@ -220,7 +220,7 @@ module iob_axis2axi_wr_int #(
       .data_o(transf_data_count)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W ((AXI_LEN_W + 1)),
       .RST_VAL(0)
    ) length_reg (
@@ -232,7 +232,7 @@ module iob_axis2axi_wr_int #(
       .data_o(length)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (2),
       .RST_VAL(0)
    ) state_reg (
@@ -245,7 +245,7 @@ module iob_axis2axi_wr_int #(
    );
 
    // AXI Interface registers
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (AXI_LEN_W),
       .RST_VAL(0)
    ) axi_awlen_reg (
@@ -257,7 +257,7 @@ module iob_axis2axi_wr_int #(
       .data_o(axi_awlen_o)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (AXI_ADDR_W),
       .RST_VAL(0)
    ) axi_awaddr_reg (
@@ -269,7 +269,7 @@ module iob_axis2axi_wr_int #(
       .data_o(axi_awaddr_o)
    );
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(0)
    ) axi_awvalid_reg (
@@ -281,7 +281,7 @@ module iob_axis2axi_wr_int #(
       .data_o(axi_awvalid_o)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (AXI_DATA_W),
       .RST_VAL(0)
    ) axi_wdata_reg (
@@ -294,7 +294,7 @@ module iob_axis2axi_wr_int #(
       .data_o(axi_wdata_o)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (1),
       .RST_VAL(0)
    ) axi_wvalid_reg (
@@ -307,7 +307,7 @@ module iob_axis2axi_wr_int #(
       .data_o(axi_wvalid_o)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (1),
       .RST_VAL(0)
    ) axi_wlast_reg (

--- a/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_wr/iob_axis2axi_wr.py
+++ b/py2hwsw/lib/hardware/buses/iob_axis2axi/submodules/iob_axis2axi_wr/iob_axis2axi_wr.py
@@ -112,11 +112,8 @@ def setup(py_params_dict):
         "subblocks": [
             {"core_name": "iob_fifo_sync"},
             {"core_name": "iob_fifo2axis"},
-            {"core_name": "iob_reg", "port_params": {"clk_en_rst_s": "cke_arst_rst"}},
-            {
-                "core_name": "iob_reg",
-                "port_params": {"clk_en_rst_s": "cke_arst_rst_en"},
-            },
+            {"core_name": "iob_reg", "port_params": {"clk_en_rst_s": "c_a_r"}},
+            {"core_name": "iob_reg", "port_params": {"clk_en_rst_s": "c_a_r_e"}},
             {"core_name": "iob_counter"},
         ],
     }

--- a/py2hwsw/lib/hardware/buses/iob_axis2fifo/hardware/src/iob_axis2fifo.v
+++ b/py2hwsw/lib/hardware/buses/iob_axis2fifo/hardware/src/iob_axis2fifo.v
@@ -31,7 +31,7 @@ module iob_axis2fifo #(
    //tready
    wire axis_tready_nxt;
    assign axis_tready_nxt = (~fifo_full_i) & en_i;
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'b0)
    ) tready_reg (
@@ -45,7 +45,7 @@ module iob_axis2fifo #(
    wire axis_tvalid_reg;
    wire in_regs_en;
    assign in_regs_en = axis_tready_o & en_i;
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (1),
       .RST_VAL(1'b0)
    ) tvalid_reg (
@@ -60,7 +60,7 @@ module iob_axis2fifo #(
    wire axis_tlast_reg;
    wire axis_tlast_nxt;
    assign axis_tlast_nxt = axis_tlast_i & axis_tvalid_i;
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (1),
       .RST_VAL(1'b0)
    ) tlast_reg (
@@ -73,7 +73,7 @@ module iob_axis2fifo #(
 
    // tdata register
    wire [DATA_W-1:0] axis_tdata_reg;
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (DATA_W),
       .RST_VAL({DATA_W{1'b0}})
    ) tdata_reg (

--- a/py2hwsw/lib/hardware/buses/iob_bus_demux/hardware/src/iob_bus_demux.v
+++ b/py2hwsw/lib/hardware/buses/iob_bus_demux/hardware/src/iob_bus_demux.v
@@ -40,7 +40,7 @@ module iob_bus_demux #(
    //
 
    wire [NB-1:0] f_sel_r;
-   iob_reg_cear_e #(
+   iob_reg_cae #(
       .DATA_W (NB),
       .RST_VAL(0)
    ) reg_f_sel (

--- a/py2hwsw/lib/hardware/buses/iob_bus_demux/iob_bus_demux.py
+++ b/py2hwsw/lib/hardware/buses/iob_bus_demux/iob_bus_demux.py
@@ -11,7 +11,7 @@ def setup(py_params_dict):
                 "name": "clk_rst_s",
                 "signals": {
                     "type": "iob_clk",
-                    "params": "arst",
+                    "params": "a",
                 },
                 "descr": "Clock and reset",
             },
@@ -21,7 +21,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_re_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
             {

--- a/py2hwsw/lib/hardware/buses/iob_fifo2axis/hardware/src/iob_fifo2axis.v
+++ b/py2hwsw/lib/hardware/buses/iob_fifo2axis/hardware/src/iob_fifo2axis.v
@@ -27,7 +27,7 @@ module iob_fifo2axis #(
    assign read_condition = axis_tready_i | (~(saved | fifo_read_r));
    assign fifo_read_o    = (en_i & (~fifo_empty_i)) & read_condition;
 
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) fifo_read_reg (
@@ -44,7 +44,7 @@ module iob_fifo2axis #(
    wire saved_nxt;
    assign saved_rst = (rst_i | output_en);
    assign saved_nxt = (fifo_read_r & (~output_en)) | saved;
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) saved_reg (
@@ -61,7 +61,7 @@ module iob_fifo2axis #(
    assign axis_tlast_nxt = (axis_word_count == len_int);
    wire saved_tlast;
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) axis_tlast_reg (
@@ -86,7 +86,7 @@ module iob_fifo2axis #(
 
    //tdata register
    wire [DATA_W-1:0] saved_tdata;
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (DATA_W),
       .RST_VAL({DATA_W{1'd0}})
    ) axis_tdata_reg (
@@ -104,7 +104,7 @@ module iob_fifo2axis #(
    assign output_nxt[1+:DATA_W] = (saved) ? saved_tdata : fifo_rdata_i;
    assign output_nxt[0]         = (saved) ? saved_tlast : axis_tlast_nxt;
    assign output_en             = (~axis_tvalid_o) | axis_tready_i;
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (DATA_W + 2),
       .RST_VAL({(DATA_W + 2) {1'd0}})
    ) output_reg (

--- a/py2hwsw/lib/hardware/buses/iob_fifo2axis/iob_fifo2axis.py
+++ b/py2hwsw/lib/hardware/buses/iob_fifo2axis/iob_fifo2axis.py
@@ -112,13 +112,13 @@ def setup(py_params_dict):
             {
                 "core_name": "iob_reg",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst",
+                    "clk_en_rst_s": "c_a_r",
                 },
             },
             {
                 "core_name": "iob_reg",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
             {

--- a/py2hwsw/lib/hardware/buses/iob_iob2apb/iob_iob2apb.py
+++ b/py2hwsw/lib/hardware/buses/iob_iob2apb/iob_iob2apb.py
@@ -140,7 +140,7 @@ def setup(py_params_dict):
                     "RST_VAL": 0,
                 },
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_en",
+                    "clk_en_rst_s": "c_a_e",
                 },
                 "connect": {
                     "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/buses/iob_iob2axil/hardware/src/iob_iob2axil.v
+++ b/py2hwsw/lib/hardware/buses/iob_iob2axil/hardware/src/iob_iob2axil.v
@@ -60,7 +60,7 @@ module iob_iob2axil #(
    //program counter
    wire [2:0] pc_cnt;
    reg  [2:0] pc_cnt_nxt;
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (3),
       .RST_VAL(3'd0)
    ) pc_reg (

--- a/py2hwsw/lib/hardware/buses/iob_iob2wishbone/iob_iob2wishbone.py
+++ b/py2hwsw/lib/hardware/buses/iob_iob2wishbone/iob_iob2wishbone.py
@@ -188,7 +188,7 @@ def setup(py_params_dict):
                 "RST_VAL": 0,
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -210,7 +210,7 @@ def setup(py_params_dict):
                 "RST_VAL": 0,
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_en",
+                "clk_en_rst_s": "c_a_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -231,7 +231,7 @@ def setup(py_params_dict):
                 "RST_VAL": 0,
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_en",
+                "clk_en_rst_s": "c_a_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -252,7 +252,7 @@ def setup(py_params_dict):
                 "RST_VAL": 0,
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_en",
+                "clk_en_rst_s": "c_a_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -273,7 +273,7 @@ def setup(py_params_dict):
                 "RST_VAL": 0,
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_en",
+                "clk_en_rst_s": "c_a_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -294,7 +294,7 @@ def setup(py_params_dict):
                 "RST_VAL": 0,
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_en",
+                "clk_en_rst_s": "c_a_e",
             },
             "connect": {
                 "clk_en_rst_s": (
@@ -315,7 +315,7 @@ def setup(py_params_dict):
                 "RST_VAL": 0,
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/buses/iob_merge/iob_merge.py
+++ b/py2hwsw/lib/hardware/buses/iob_merge/iob_merge.py
@@ -242,7 +242,7 @@ def setup(py_params_dict):
                 "RST_VAL": f"{NBITS}'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst",
+                "clk_en_rst_s": "c_a_r",
             },
             "connect": {
                 "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/buses/iob_split/iob_split.py
+++ b/py2hwsw/lib/hardware/buses/iob_split/iob_split.py
@@ -228,7 +228,7 @@ def setup(py_params_dict):
                 "RST_VAL": f"{NBITS}'b0",
             },
             "port_params": {
-                "clk_en_rst_s": "cke_arst_rst_en",
+                "clk_en_rst_s": "c_a_r_e",
             },
             "connect": {
                 "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/buses/iob_wishbone2iob/iob_wishbone2iob.py
+++ b/py2hwsw/lib/hardware/buses/iob_wishbone2iob/iob_wishbone2iob.py
@@ -132,7 +132,7 @@ def setup(py_params_dict):
                     "RST_VAL": 0,
                 },
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
                 "connect": {
                     "clk_en_rst_s": (
@@ -154,7 +154,7 @@ def setup(py_params_dict):
                     "RST_VAL": 0,
                 },
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
                 "connect": {
                     "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/fifo/iob_bfifo/hardware/src/iob_bfifo.v
+++ b/py2hwsw/lib/hardware/fifo/iob_bfifo/hardware/src/iob_bfifo.v
@@ -82,7 +82,7 @@ module iob_bfifo #(
   end
 
   //data register
-  iob_reg_cear_r #(
+  iob_reg_car #(
       .DATA_W (BUFFER_SIZE),
       .RST_VAL({BUFFER_SIZE{1'b0}})
   ) data_reg_inst (
@@ -93,7 +93,7 @@ module iob_bfifo #(
   );
 
   //read pointer
-  iob_reg_cear_r #(
+  iob_reg_car #(
       .DATA_W ($clog2(BUFFER_SIZE)),
       .RST_VAL({$clog2(BUFFER_SIZE) {1'b0}})
   ) rptr_reg (
@@ -104,7 +104,7 @@ module iob_bfifo #(
   );
 
   //write pointer
-  iob_reg_cear_r #(
+  iob_reg_car #(
       .DATA_W ($clog2(BUFFER_SIZE)),
       .RST_VAL({$clog2(BUFFER_SIZE) {1'b0}})
   ) wptr_reg (
@@ -115,7 +115,7 @@ module iob_bfifo #(
   );
 
   //fifo level
-  iob_reg_cear_r #(
+  iob_reg_car #(
       .DATA_W ($clog2(BUFFER_SIZE) + 1),
       .RST_VAL({$clog2(BUFFER_SIZE) + 1{1'b0}})
   ) level_reg (

--- a/py2hwsw/lib/hardware/fifo/iob_bfifo/iob_bfifo.py
+++ b/py2hwsw/lib/hardware/fifo/iob_bfifo/iob_bfifo.py
@@ -11,7 +11,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_r_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst",
+                    "clk_en_rst_s": "c_a_r",
                 },
             },
             # For simulation

--- a/py2hwsw/lib/hardware/fifo/iob_fifo_sync/hardware/src/iob_fifo_sync.v
+++ b/py2hwsw/lib/hardware/fifo/iob_fifo_sync/hardware/src/iob_fifo_sync.v
@@ -67,7 +67,7 @@ module iob_fifo_sync #(
    //FIFO level
    reg  [ADDR_W:0] level_nxt;
    wire [ADDR_W:0] level_int;
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (ADDR_W + 1),
       .RST_VAL({(ADDR_W + 1) {1'd0}})
    ) level_reg0 (
@@ -96,7 +96,7 @@ module iob_fifo_sync #(
    //FIFO empty
    wire r_empty_nxt;
    assign r_empty_nxt = level_nxt < {1'b0, R_INCR};
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'd1)
    ) r_empty_reg0 (
@@ -109,7 +109,7 @@ module iob_fifo_sync #(
    //FIFO full
    wire w_full_nxt;
    assign w_full_nxt = level_nxt > (FIFO_SIZE - W_INCR);
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) w_full_reg0 (

--- a/py2hwsw/lib/hardware/fifo/iob_fifo_sync/iob_fifo_sync.py
+++ b/py2hwsw/lib/hardware/fifo/iob_fifo_sync/iob_fifo_sync.py
@@ -200,7 +200,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_r_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst",
+                    "clk_en_rst_s": "c_a_r",
                 },
             },
             {

--- a/py2hwsw/lib/hardware/fifo/iob_gray_counter/hardware/src/iob_gray_counter.v
+++ b/py2hwsw/lib/hardware/fifo/iob_gray_counter/hardware/src/iob_gray_counter.v
@@ -30,7 +30,7 @@ module iob_gray_counter #(
     end
   endgenerate
 
-  iob_reg_cear_re #(
+  iob_reg_care #(
       .DATA_W (W),
       .RST_VAL({{(W - 1) {1'd0}}, 1'd1})
   ) bin_counter_reg (
@@ -43,7 +43,7 @@ module iob_gray_counter #(
       .data_o(bin_counter)
   );
 
-  iob_reg_cear_re #(
+  iob_reg_care #(
       .DATA_W (W),
       .RST_VAL({W{1'd0}})
   ) gray_counter_reg (

--- a/py2hwsw/lib/hardware/fifo/iob_gray_counter/iob_gray_counter.py
+++ b/py2hwsw/lib/hardware/fifo/iob_gray_counter/iob_gray_counter.py
@@ -21,7 +21,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_re_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
         ],

--- a/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
+++ b/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
@@ -126,7 +126,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_e_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_en",
+                    "clk_en_rst_s": "c_a_e",
                 },
                 "instantiate": False,
             },

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
@@ -275,7 +275,7 @@ class csr_gen:
                     },
                 )
                 lines += f"    assign {name_idx}_wen = internal_iob_valid & (write_en & {name_idx}_addressed_w);\n"
-                lines += "    iob_reg_cear_e #(\n"
+                lines += "    iob_reg_cae #(\n"
                 lines += f"      .DATA_W({n_bits}),\n"
                 lines += f"      .RST_VAL({rst_val_str})\n"
                 lines += f"    ) {name_idx}_datareg (\n"

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
@@ -686,7 +686,7 @@ class csr_gen:
                     "RST_VAL": "{ADDR_W{1'b0}}",
                 },
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_en",
+                    "clk_en_rst_s": "c_a_e",
                 },
                 "connect": {
                     "clk_en_rst_s": (

--- a/py2hwsw/lib/hardware/memories/iob_ahb_ram/iob_ahb_ram.py
+++ b/py2hwsw/lib/hardware/memories/iob_ahb_ram/iob_ahb_ram.py
@@ -29,7 +29,7 @@ def setup(py_params_dict):
                 "name": "clk_en_rst_s",
                 "signals": {
                     "type": "iob_clk",
-                    "params": "arstn",
+                    "params": "an",
                 },
                 "descr": "Clock, clock enable and reset",
             },

--- a/py2hwsw/lib/hardware/memories/iob_memwrapper/iob_memwrapper.py
+++ b/py2hwsw/lib/hardware/memories/iob_memwrapper/iob_memwrapper.py
@@ -27,11 +27,14 @@ def setup(py_params_dict):
 
     mwrap_wires = []
     mwrap_ports = []
+    memory_ports = []
     for port in attrs["ports"]:
         if isinstance(port["signals"], dict):
             if port["signals"]["type"] in mem_if_names:
                 wire = copy.deepcopy(port)
+                wire["name"] = wire["name"][:-2]
                 mwrap_wires.append(wire)
+                memory_ports.append(port)
             else:
                 mwrap_ports.append(port)
         else:
@@ -41,6 +44,11 @@ def setup(py_params_dict):
 
     attributes_dict["wires"] = mwrap_wires
 
+    connect_dict = {
+        p["name"]: w["name"]
+        for p, w in zip(memory_ports + mwrap_ports, mwrap_wires + mwrap_ports)
+    }
+
     attributes_dict["subblocks"] = [
         {
             "core_name": attrs["original_name"],
@@ -49,7 +57,7 @@ def setup(py_params_dict):
             "parameters": {
                 i["name"]: i["name"] for i in attrs["confs"] if i["type"] in ["P", "F"]
             },
-            "connect": {i["name"]: i["name"] for i in attrs["ports"]},
+            "connect": connect_dict,
         }
     ]
 

--- a/py2hwsw/lib/hardware/memories/regfile/iob_regfile_2p/hardware/src/iob_regfile_2p.v
+++ b/py2hwsw/lib/hardware/memories/regfile/iob_regfile_2p/hardware/src/iob_regfile_2p.v
@@ -65,7 +65,7 @@ module iob_regfile_2p #(
          ) begin : g_columns
             if ((row_sel + col_sel) < N) begin : g_if
                assign wen[row_sel+col_sel] = wen_i & (waddr_int == (row_sel + col_sel)) & wstrb[col_sel];
-               iob_reg_cear_e #(
+               iob_reg_cae #(
                   .DATA_W (W),
                   .RST_VAL({W{1'b0}})
                ) iob_reg_inst (

--- a/py2hwsw/lib/hardware/memories/regfile/iob_regfile_at2p/hardware/src/iob_regfile_at2p.v
+++ b/py2hwsw/lib/hardware/memories/regfile/iob_regfile_at2p/hardware/src/iob_regfile_at2p.v
@@ -32,7 +32,7 @@ module iob_regfile_at2p #(
    generate
       for (addr = 0; addr < (2 ** ADDR_W); addr = addr + 1) begin : gen_register_file
          assign regfile_en[addr] = (w_addr_i == addr);
-         iob_reg_cear_e #(
+         iob_reg_cae #(
             .DATA_W (DATA_W),
             .RST_VAL({DATA_W{1'd0}})
          ) rdata (
@@ -50,7 +50,7 @@ module iob_regfile_at2p #(
    assign r_data = regfile_in[r_addr_i*DATA_W+:DATA_W];
 
    //read
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (DATA_W),
       .RST_VAL({DATA_W{1'd0}})
    ) rdata (

--- a/py2hwsw/lib/hardware/memories/regfile/iob_regfile_at2p/iob_regfile_at2p.py
+++ b/py2hwsw/lib/hardware/memories/regfile/iob_regfile_at2p/iob_regfile_at2p.py
@@ -15,7 +15,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_e_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_en",
+                    "clk_en_rst_s": "c_a_e",
                 },
             },
         ],

--- a/py2hwsw/lib/hardware/memories/regfile/iob_regfile_sp/hardware/src/iob_regfile_sp.v
+++ b/py2hwsw/lib/hardware/memories/regfile/iob_regfile_sp/hardware/src/iob_regfile_sp.v
@@ -27,7 +27,7 @@ module iob_regfile_sp #(
       for (i = 0; i < 2 ** ADDR_W; i = i + 1) begin : g_regfile
          wire reg_en_i;
          assign reg_en_i = we_i & (addr_i == i);
-         iob_reg_cear_re #(
+         iob_reg_care #(
             .DATA_W(DATA_W)
          ) regfile_sp_inst (
             `include "iob_regfile_sp_iob_clk_s_s_portmap.vs"

--- a/py2hwsw/lib/hardware/memories/regfile/iob_regfile_sp/iob_regfile_sp.py
+++ b/py2hwsw/lib/hardware/memories/regfile/iob_regfile_sp/iob_regfile_sp.py
@@ -21,7 +21,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_re_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
         ],

--- a/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
+++ b/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
@@ -14,18 +14,18 @@ def setup(py_params_dict):
 
     clk_s_params = [x for x in port_params["clk_en_rst_s"].split("_") if x != ""]
 
-    suffix_dict = {
-        "cke": "c",
-        "cken": "cn",
-        "arst": "a",
-        "arstn": "an",
-        "rst": "r",
-        "rstn": "rn",
-        "en": "e",
-        "enn": "en",
-    }
+    suffix_list = [
+        "c",
+        "cn",
+        "a",
+        "an",
+        "r",
+        "rn",
+        "e",
+        "en",
+    ]
 
-    suffix = "".join([suffix_dict[x] for x in suffix_dict if x in clk_s_params])
+    suffix = "".join([suffix_list for x in suffix_list if x in clk_s_params])
 
     reg_type = "iob_regn" if "n" in clk_s_params else "iob_reg"
 
@@ -35,29 +35,27 @@ def setup(py_params_dict):
     en_str = ""
 
     sensitivity_list = "negedge clk_i" if "n" in clk_s_params else "posedge clk_i"
-    if "arst" in clk_s_params:
+    if "a" in clk_s_params:
         sensitivity_list = f"{sensitivity_list}, posedge arst_i"
-    elif "arstn" in clk_s_params:
+    elif "an" in clk_s_params:
         sensitivity_list = f"{sensitivity_list}, negedge arst_n_i"
 
-    if any([x in clk_s_params for x in ["arst", "arstn"]]):
-        arst_con = " | ".join(
-            [f"{x}_i" for x in ["arst", "arstn"] if x in clk_s_params]
-        ).replace("arstn", "~arst_n")
+    if any([x in clk_s_params for x in ["a", "an"]]):
+        arst_con = f"{'arst' if 'a' in clk_s_params else '~arst_n'}_i"
         rst_str += f"        if ({arst_con}) begin\n            data_o <= RST_VAL;\n        end"
-    if any([x in clk_s_params for x in ["rst", "rstn"]]):
-        rst_con = " | ".join(
-            [f"{x}_i" for x in ["rst", "rstn"] if x in clk_s_params]
-        ).replace("rstn", "~rst_n")
+    if any([x in clk_s_params for x in ["r", "rn"]]):
+        rst_con = f"{'rst' if 'r' in clk_s_params else '~rst_n'}_i"
         rst_str += f"{' else ' if rst_str != '' else '        '}if ({rst_con}) begin\n            data_o <= RST_VAL;\n        end"
 
-    if any([x in clk_s_params for x in ["cke", "cken", "en", "enn"]]):
+    if any([x in clk_s_params for x in ["c", "cn", "e", "en"]]):
         en_con = (
             " & ".join(
-                [f"{x}_i" for x in ["cke", "cken", "en", "enn"] if x in clk_s_params]
+                [f"{x}_i" for x in ["c", "cn", "e", "en"] if x in clk_s_params]
             )
-            .replace("cken", "~cke_n")
-            .replace("enn", "~en_n")
+            .replace("cn_i", "~cke_n_i")
+            .replace("en_i", "~en_n_i")
+            .replace("c_i", "cke_i")
+            .replace("e_i", "en_i")
         )
         en_str = f"{'else ' if rst_str != '' else '        '}if ({en_con}) begin\n            data_o <= data_i;\n        end"
     else:

--- a/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
+++ b/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
@@ -14,28 +14,24 @@ def setup(py_params_dict):
 
     clk_s_params = [x for x in port_params["clk_en_rst_s"].split("_") if x != ""]
 
-    clk_suff_dict = {
-        "cke": "ce",
-        "cken": "cen",
-        "arst": "ar",
-        "arstn": "arn",
-    }
-
-    sync_suff_dict = {
+    suffix_dict = {
+        "cke": "c",
+        "cken": "cn",
+        "arst": "a",
+        "arstn": "an",
         "rst": "r",
         "rstn": "rn",
         "en": "e",
         "enn": "en",
     }
 
-    clk_suffix = "".join([clk_suff_dict[x] for x in clk_s_params if x in clk_suff_dict])
-    sync_suffix = "".join(
-        [sync_suff_dict[x] for x in clk_s_params if x in sync_suff_dict]
+    suffix = "".join(
+        [suffix_dict[x] for x in suffix_dict if x in clk_s_params]
     )
 
     reg_type = "iob_regn" if "n" in clk_s_params else "iob_reg"
 
-    reg_name = "_".join(filter(lambda x: x != "", [reg_type, clk_suffix, sync_suffix]))
+    reg_name = "_".join(filter(lambda x: x != "", [reg_type, suffix]))
 
     rst_str = ""
     en_str = ""

--- a/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
+++ b/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
@@ -25,9 +25,7 @@ def setup(py_params_dict):
         "enn": "en",
     }
 
-    suffix = "".join(
-        [suffix_dict[x] for x in suffix_dict if x in clk_s_params]
-    )
+    suffix = "".join([suffix_dict[x] for x in suffix_dict if x in clk_s_params])
 
     reg_type = "iob_regn" if "n" in clk_s_params else "iob_reg"
 

--- a/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
+++ b/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
@@ -2,13 +2,15 @@
 #
 # SPDX-License-Identifier: MIT
 
+import sys
+
 
 def setup(py_params_dict):
 
     port_params = (
         py_params_dict["port_params"]
         if "port_params" in py_params_dict
-        else {"clk_en_rst_s": "cke_arst"}
+        else {"clk_en_rst_s": "c_a"}
     )
     assert "clk_en_rst_s" in port_params, "clk_en_rst_s port is missing"
 
@@ -25,7 +27,7 @@ def setup(py_params_dict):
         "en",
     ]
 
-    suffix = "".join([suffix_list for x in suffix_list if x in clk_s_params])
+    suffix = "".join([x for x in suffix_list if x in clk_s_params])
 
     reg_type = "iob_regn" if "n" in clk_s_params else "iob_reg"
 
@@ -49,13 +51,11 @@ def setup(py_params_dict):
 
     if any([x in clk_s_params for x in ["c", "cn", "e", "en"]]):
         en_con = (
-            " & ".join(
-                [f"{x}_i" for x in ["c", "cn", "e", "en"] if x in clk_s_params]
-            )
+            " & ".join([f"{x}_i" for x in ["c", "cn", "e", "en"] if x in clk_s_params])
             .replace("cn_i", "~cke_n_i")
             .replace("en_i", "~en_n_i")
-            .replace("c_i", "cke_i")
             .replace("e_i", "en_i")
+            .replace("c_i", "cke_i")
         )
         en_str = f"{'else ' if rst_str != '' else '        '}if ({en_con}) begin\n            data_o <= data_i;\n        end"
     else:

--- a/py2hwsw/lib/hardware/shifters/iob_pack/hardware/src/iob_pack.v
+++ b/py2hwsw/lib/hardware/shifters/iob_pack/hardware/src/iob_pack.v
@@ -111,7 +111,7 @@ module iob_pack #(
   );
 
   //wrap control accumulator
-  iob_reg_cear_r #(
+  iob_reg_car #(
       .DATA_W ($clog2(DATA_W) + 1),
       .RST_VAL({$clog2(DATA_W) + 1{1'b0}})
   ) wrap_acc_reg (
@@ -122,7 +122,7 @@ module iob_pack #(
   );
 
   //pcnt register (state counter)
-  iob_reg_cear_r #(
+  iob_reg_car #(
       .DATA_W (2),
       .RST_VAL(2'b0)
   ) pcnt_reg (

--- a/py2hwsw/lib/hardware/shifters/iob_shift_reg/hardware/src/iob_shift_reg.v
+++ b/py2hwsw/lib/hardware/shifters/iob_shift_reg/hardware/src/iob_shift_reg.v
@@ -78,7 +78,7 @@ module iob_shift_reg #(
       .data_o(addr_w)
   );
 
-  iob_reg_cear #(
+  iob_reg_ca #(
       .DATA_W (1),
       .RST_VAL(0)
   ) out_enable (

--- a/py2hwsw/lib/hardware/shifters/iob_sipo_reg/hardware/src/iob_sipo_reg.v
+++ b/py2hwsw/lib/hardware/shifters/iob_sipo_reg/hardware/src/iob_sipo_reg.v
@@ -17,7 +17,7 @@ module iob_sipo_reg #(
   wire [DATA_W-1:0] data;
   assign data = {p_o[DATA_W-2:0], s_i};
 
-  iob_reg_cear #(
+  iob_reg_ca #(
       .DATA_W (DATA_W),
       .RST_VAL(0)
   ) reg0 (

--- a/py2hwsw/lib/hardware/shifters/iob_unpack/hardware/src/iob_unpack.v
+++ b/py2hwsw/lib/hardware/shifters/iob_unpack/hardware/src/iob_unpack.v
@@ -111,7 +111,7 @@ module iob_unpack #(
   );
 
   //wrap control accumulator
-  iob_reg_cear_r #(
+  iob_reg_car #(
       .DATA_W ($clog2(DATA_W) + 1),
       .RST_VAL({$clog2(DATA_W) + 1{1'b0}})
   ) wrap_acc_reg (
@@ -122,7 +122,7 @@ module iob_unpack #(
   );
 
   //pcnt register (state counter)
-  iob_reg_cear_r #(
+  iob_reg_car #(
       .DATA_W (2),
       .RST_VAL(2'b0)
   ) pcnt_reg (

--- a/py2hwsw/lib/hardware/synchronizers/iob_f2s_1bit_sync/hardware/src/iob_f2s_1bit_sync.v
+++ b/py2hwsw/lib/hardware/synchronizers/iob_f2s_1bit_sync/hardware/src/iob_f2s_1bit_sync.v
@@ -15,7 +15,7 @@ module iob_f2s_1bit_sync (
    wire [1:0] data;
    assign data = {sync[0], 1'b0};
 
-   iob_reg_cear #(2, 1) reg0 (
+   iob_reg_ca #(2, 1) reg0 (
       .clk_i (clk_i),
       .arst_i(value_i),
       .cke_i (cke_i),

--- a/py2hwsw/lib/hardware/synchronizers/iob_reset_sync/iob_reset_sync.py
+++ b/py2hwsw/lib/hardware/synchronizers/iob_reset_sync/iob_reset_sync.py
@@ -16,7 +16,7 @@ def setup(py_params_dict):
                 "name": "clk_rst_s",
                 "signals": {
                     "type": "iob_clk",
-                    "params": "arst",
+                    "params": "a",
                 },
                 "descr": "clock and reset",
             },
@@ -56,7 +56,7 @@ def setup(py_params_dict):
                     "RST_VAL": "2'd3" if edge else "2'd0",
                 },
                 "port_params": {
-                    "clk_en_rst_s": "arst",
+                    "clk_en_rst_s": "a",
                 },
                 "connect": {
                     "clk_en_rst_s": "clk_rst_s",

--- a/py2hwsw/lib/hardware/synchronizers/iob_sync/iob_sync.py
+++ b/py2hwsw/lib/hardware/synchronizers/iob_sync/iob_sync.py
@@ -29,7 +29,7 @@ def setup(py_params_dict):
                 "name": "clk_rst_s",
                 "signals": {
                     "type": "iob_clk",
-                    "params": "arst",
+                    "params": "a",
                 },
                 "descr": "Clock and reset",
             },
@@ -72,7 +72,7 @@ def setup(py_params_dict):
                     "RST_VAL": "RST_VAL",
                 },
                 "port_params": {
-                    "clk_en_rst_s": "arst",
+                    "clk_en_rst_s": "a",
                 },
                 "connect": {
                     "clk_en_rst_s": "clk_rst_s",
@@ -88,7 +88,7 @@ def setup(py_params_dict):
                     "RST_VAL": "RST_VAL",
                 },
                 "port_params": {
-                    "clk_en_rst_s": "arst",
+                    "clk_en_rst_s": "a",
                 },
                 "connect": {
                     "clk_en_rst_s": "clk_rst_s",

--- a/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_zybo_z7/iob_system_iob_zybo_z7/iob_system_iob_zybo_z7.py
+++ b/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_zybo_z7/iob_system_iob_zybo_z7/iob_system_iob_zybo_z7.py
@@ -106,7 +106,7 @@ def setup(py_params_dict):
             "descr": "Clock and reset",
             "signals": {
                 "type": "iob_clk",
-                "params": "arst",
+                "params": "a",
             },
         },
         {
@@ -129,7 +129,7 @@ def setup(py_params_dict):
             "signals": {
                 "type": "iob_clk",
                 "prefix": "intercon_m_",
-                "params": "arst",
+                "params": "a",
             },
         },
         {

--- a/py2hwsw/lib/peripherals/iob_axistream_in/hardware/src/iob_axistream_in.v
+++ b/py2hwsw/lib/peripherals/iob_axistream_in/hardware/src/iob_axistream_in.v
@@ -114,7 +114,7 @@ module iob_axistream_in #(
             endcase
          end
 
-         iob_reg_cear_re #(
+         iob_reg_care #(
             .DATA_W (1),
             .RST_VAL(1'd0)
          ) fifo_write_state_reg (
@@ -231,7 +231,7 @@ module iob_axistream_in #(
       .detected_o(axis_tlast_detected)
    );
 
-   iob_reg_cear #(
+   iob_reg_ca #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) tlast_detect_reg (

--- a/py2hwsw/lib/peripherals/iob_axistream_in/iob_axistream_in.py
+++ b/py2hwsw/lib/peripherals/iob_axistream_in/iob_axistream_in.py
@@ -341,7 +341,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instantiate": False,
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
             {

--- a/py2hwsw/lib/peripherals/iob_axistream_out/hardware/src/iob_axistream_out.v
+++ b/py2hwsw/lib/peripherals/iob_axistream_out/hardware/src/iob_axistream_out.v
@@ -106,7 +106,7 @@ module iob_axistream_out #(
    end
 
    // program counter
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (1),
       .RST_VAL(1'd0)
    ) tvalid_reg (

--- a/py2hwsw/lib/peripherals/iob_axistream_out/iob_axistream_out.py
+++ b/py2hwsw/lib/peripherals/iob_axistream_out/iob_axistream_out.py
@@ -322,7 +322,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instantiate": False,
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
             {

--- a/py2hwsw/lib/peripherals/iob_nco/hardware/modules/iob_nco_sync/hardware/src/iob_nco_sync.v
+++ b/py2hwsw/lib/peripherals/iob_nco/hardware/modules/iob_nco_sync/hardware/src/iob_nco_sync.v
@@ -106,7 +106,7 @@ module iob_nco_sync #(
    );
 
    //fractional period value register
-   iob_reg_cear_r #(
+   iob_reg_car #(
       .DATA_W (1),
       .RST_VAL(1'b0)
    ) period_wen_reg (

--- a/py2hwsw/lib/peripherals/iob_nco/hardware/src/iob_nco.v
+++ b/py2hwsw/lib/peripherals/iob_nco/hardware/src/iob_nco.v
@@ -32,7 +32,7 @@ module iob_nco #(
    wire [(2*DATA_W)-1:0] period_full_wdata;
    wire                  period_full_wen;
    // integer period value register
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(DATA_W)
    ) int_reg (
       .clk_i (clk_i),
@@ -44,7 +44,7 @@ module iob_nco #(
       .data_o(period_full_wdata[DATA_W+:DATA_W])
    );
    // fractional period value register
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(DATA_W)
    ) frac_reg (
       .clk_i (clk_i),
@@ -63,7 +63,7 @@ module iob_nco #(
    assign per_valid_en  = period_int_wen_wr | period_frac_wen_wr;
    assign per_valid_rst = soft_reset_wr | (&per_valid);
    assign per_valid_nxt = per_valid | ({period_int_wen_wr, period_frac_wen_wr});
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(2)
    ) valid_reg (
       .clk_i (clk_i),
@@ -117,7 +117,7 @@ module iob_nco #(
    end
 
    //fractional period value register
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(PERIOD_W)
    ) per_reg (
       .clk_i (clk_in_i),
@@ -130,7 +130,7 @@ module iob_nco #(
    );
 
    //output clock register
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(1)
    ) clk_out_reg (
       .clk_i (clk_in_i),

--- a/py2hwsw/lib/peripherals/iob_nco/iob_nco.py
+++ b/py2hwsw/lib/peripherals/iob_nco/iob_nco.py
@@ -178,7 +178,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instantiate": False,
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
             {

--- a/py2hwsw/lib/peripherals/iob_regfileif/software/python/mkregsregfileif.py
+++ b/py2hwsw/lib/peripherals/iob_regfileif/software/python/mkregsregfileif.py
@@ -100,7 +100,7 @@ def create_regs(filename, program):
 
             file_contents.append("`IOB_WIRE({}, {})\n".format(reg_name, reg_size_bits))
             file_contents.append(
-                "iob_reg_cear #(.DATA_W({}),.RST_VAL({}))\n".format(
+                "iob_reg_ca #(.DATA_W({}),.RST_VAL({}))\n".format(
                     reg_size_bits, reg_rst_val
                 )
             )

--- a/py2hwsw/lib/peripherals/iob_timer/hardware/iob_timer_core/iob_timer_core.py
+++ b/py2hwsw/lib/peripherals/iob_timer/hardware/iob_timer_core/iob_timer_core.py
@@ -30,7 +30,7 @@ def setup(py_params_dict):
                 "core_name": "iob_reg",
                 "instance_name": "iob_reg_re_inst",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_rst_en",
+                    "clk_en_rst_s": "c_a_r_e",
                 },
             },
             {

--- a/py2hwsw/lib/peripherals/iob_timer/hardware/src/iob_timer_core.v
+++ b/py2hwsw/lib/peripherals/iob_timer/hardware/src/iob_timer_core.v
@@ -32,7 +32,7 @@ module iob_timer_core #(
    );
 
    //time counter register
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W (2 * DATA_W),
       .RST_VAL(0)
    ) time_counter_reg (

--- a/py2hwsw/lib/peripherals/iob_uart/hardware/iob_uart_core/iob_uart_core.py
+++ b/py2hwsw/lib/peripherals/iob_uart/hardware/iob_uart_core/iob_uart_core.py
@@ -11,7 +11,7 @@ def setup(py_params_dict):
                 "name": "clk_rst_s",
                 "signals": {
                     "type": "iob_clk",
-                    "params": "arst",
+                    "params": "a",
                 },
                 "descr": "Clock and reset",
             },
@@ -46,7 +46,7 @@ def setup(py_params_dict):
             {
                 "core_name": "iob_reg",
                 "port_params": {
-                    "clk_en_rst_s": "cke_arst_en",
+                    "clk_en_rst_s": "c_a_e",
                 },
             },
         ],

--- a/py2hwsw/lib/peripherals/iob_uart/hardware/src/iob_uart_core.v
+++ b/py2hwsw/lib/peripherals/iob_uart/hardware/src/iob_uart_core.v
@@ -35,7 +35,7 @@ module iob_uart_core (
    always @(posedge clk_i) cts_int <= {cts_int[0], rs232_cts_i};
 
    wire [7:0] tx_data_int;
-   iob_reg_cear_e #(
+   iob_reg_cae #(
       .DATA_W (8),
       .RST_VAL(8'b0)
    ) txdata_reg (

--- a/py2hwsw/lib/peripherals/iob_uart/iob_uart.py
+++ b/py2hwsw/lib/peripherals/iob_uart/iob_uart.py
@@ -193,7 +193,7 @@ def setup(py_params_dict):
                     "DATA_W": 1,
                     "RST_VAL": "1'b0",
                 },
-                "port_params": {"clk_en_rst_s": "cke_arst_rst_en"},
+                "port_params": {"clk_en_rst_s": "c_a_r_e"},
                 "connect": {
                     "clk_en_rst_s": (
                         "clk_en_rst_s",

--- a/py2hwsw/lib/peripherals/iob_uart/iob_uart_core.v
+++ b/py2hwsw/lib/peripherals/iob_uart/iob_uart_core.v
@@ -46,7 +46,7 @@ module iob_uart_core (
    assign txen = tx_en_i & cts_int;
 
    wire [7:0] tx_data_int;
-   iob_reg_cear_e #(
+   iob_reg_cae #(
       .DATA_W (8),
       .RST_VAL(8'b0)
    ) txdata_reg (
@@ -77,7 +77,7 @@ module iob_uart_core (
 
    reg         tx_ready_nxt;
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(2)
    ) tx_pc_reg (
       .clk_i (clk_i),
@@ -89,7 +89,7 @@ module iob_uart_core (
       .data_o(tx_pc)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(1)
    ) tx_ready_reg (
       .clk_i (clk_i),
@@ -101,7 +101,7 @@ module iob_uart_core (
       .data_o(tx_ready_o)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(10)
    ) tx_pattern_reg (
       .clk_i (clk_i),
@@ -113,7 +113,7 @@ module iob_uart_core (
       .data_o(tx_pattern)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(4)
    ) tx_bitcnt_reg (
       .clk_i (clk_i),
@@ -125,7 +125,7 @@ module iob_uart_core (
       .data_o(tx_bitcnt)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(16)
    ) tx_cyclecnt_reg (
       .clk_i (clk_i),
@@ -191,7 +191,7 @@ module iob_uart_core (
 
    reg         rx_ready_nxt;
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(3)
    ) rx_pc_reg (
       .clk_i (clk_i),
@@ -206,7 +206,7 @@ module iob_uart_core (
    wire rxready_rst;
    assign rxready_rst = rst_soft_i | data_read_en_i;
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(1)
    ) rx_ready_reg (
       .clk_i (clk_i),
@@ -218,7 +218,7 @@ module iob_uart_core (
       .data_o(rx_ready_o)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(8)
    ) rx_pattern_reg (
       .clk_i (clk_i),
@@ -230,7 +230,7 @@ module iob_uart_core (
       .data_o(rx_pattern)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(4)
    ) rx_bitcnt_reg (
       .clk_i (clk_i),
@@ -242,7 +242,7 @@ module iob_uart_core (
       .data_o(rx_bitcnt)
    );
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(16)
    ) rx_cyclecnt_reg (
       .clk_i (clk_i),
@@ -257,7 +257,7 @@ module iob_uart_core (
 
    reg rs232_rts_nxt;
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(1)
    ) rts_reg (
       .clk_i (clk_i),
@@ -271,7 +271,7 @@ module iob_uart_core (
 
    reg [7:0] rx_data_nxt;
 
-   iob_reg_cear_re #(
+   iob_reg_care #(
       .DATA_W(8)
    ) rx_data_reg (
       .clk_i (clk_i),

--- a/py2hwsw/scripts/block_gen.py
+++ b/py2hwsw/scripts/block_gen.py
@@ -143,16 +143,11 @@ def get_instance_port_connections(instance):
             continue
         instance_portmap += f"        // {port.name} port: {port.descr}\n"
         if isinstance(port.e_connect, str):
-            if len(port.signals) == 1:
-                if "z" in port.e_connect.lower():
-                    instance_portmap += f"        .{port.signals[0].name}(),\n"
-                else:
-                    instance_portmap += f"        .{port.signals[0].name}({port.e_connect}),\n"
-                continue
+            if "z" in port.e_connect.lower():
+                instance_portmap += f"        .{port.signals[0].name}(),\n"
             else:
-                fail_with_msg(
-                    f"{iob_colors.FAIL}Port '{port.name}' of instance '{instance.name}' has more than one signal but is connected to one constant value '{port.e_connect}'!{iob_colors.ENDC}"
-                )
+                instance_portmap += f"        .{port.signals[0].name}({port.e_connect}),\n"
+            continue
         # Connect individual signals
         for idx, signal in enumerate(port.signals):
             if not isinstance(signal, iob_signal):

--- a/py2hwsw/scripts/block_gen.py
+++ b/py2hwsw/scripts/block_gen.py
@@ -138,7 +138,7 @@ def get_instance_port_connections(instance):
             port.e_connect
         ), f"{iob_colors.FAIL}Port '{port.name}' of instance '{instance.name}' is not connected!{iob_colors.ENDC}"
         newlinechar = "\n"
-        if not port.interface or not port.e_connect.interface:
+        if (not port.interface or not port.e_connect.interface) and not isinstance(port.e_connect, str):
             assert len(port.signals) == len(
                 port.e_connect.signals
             ), f"""{iob_colors.FAIL}Port '{port.name}' of instance '{instance.name}' has different number of signals compared to external connection '{port.e_connect.name}'!
@@ -155,7 +155,10 @@ External connection '{get_real_signal(port.e_connect).name}' has the following s
         instance_portmap += f"        // {port.name} port: {port.descr}\n"
         if isinstance(port.e_connect, str):
             if len(port.signals) == 1:
-                instance_portmap += f"        .{port.signal[0].name}({port.e_connect}),\n"
+                if "z" in port.e_connect.lower():
+                    instance_portmap += f"        .{port.signals[0].name}(),\n"
+                else:
+                    instance_portmap += f"        .{port.signals[0].name}({port.e_connect}),\n"
                 continue
             else:
                 fail_with_msg(

--- a/py2hwsw/scripts/block_gen.py
+++ b/py2hwsw/scripts/block_gen.py
@@ -153,6 +153,14 @@ External connection '{get_real_signal(port.e_connect).name}' has the following s
         if not any(isinstance(signal, iob_signal) for signal in port.signals):
             continue
         instance_portmap += f"        // {port.name} port: {port.descr}\n"
+        if isinstance(port.e_connect, str):
+            if len(port.signals) == 1:
+                instance_portmap += f"        .{port.signal[0].name}({port.e_connect}),\n"
+                continue
+            else:
+                fail_with_msg(
+                    f"{iob_colors.FAIL}Port '{port.name}' of instance '{instance.name}' has more than one signal but is connected to one constant value '{port.e_connect}'!{iob_colors.ENDC}"
+                )
         # Connect individual signals
         for idx, signal in enumerate(port.signals):
             if not isinstance(signal, iob_signal):

--- a/py2hwsw/scripts/block_gen.py
+++ b/py2hwsw/scripts/block_gen.py
@@ -137,17 +137,6 @@ def get_instance_port_connections(instance):
         assert (
             port.e_connect
         ), f"{iob_colors.FAIL}Port '{port.name}' of instance '{instance.name}' is not connected!{iob_colors.ENDC}"
-        newlinechar = "\n"
-        if (not port.interface or not port.e_connect.interface) and not isinstance(port.e_connect, str):
-            assert len(port.signals) == len(
-                port.e_connect.signals
-            ), f"""{iob_colors.FAIL}Port '{port.name}' of instance '{instance.name}' has different number of signals compared to external connection '{port.e_connect.name}'!
-Port '{port.name}' has the following signals:
-{newlinechar.join("- " + get_real_signal(port).name for port in port.signals)}
-
-External connection '{get_real_signal(port.e_connect).name}' has the following signals:
-{newlinechar.join("- " + get_real_signal(port).name for port in port.e_connect.signals)}
-{iob_colors.ENDC}"""
 
         # If port has only non-iob signals, skip it
         if not any(isinstance(signal, iob_signal) for signal in port.signals):

--- a/py2hwsw/scripts/if_gen.py
+++ b/py2hwsw/scripts/if_gen.py
@@ -421,13 +421,13 @@ def get_iob_ports():
 @parse_widths
 def get_iob_clk_ports(params: str = None):
     if params is None:
-        params = "cke_arst"
+        params = "c_a"
     params = params.split("_")
     if (
-        all(x in params for x in ["arst", "arstn"])
-        or all(x in params for x in ["rst", "rstn"])
-        or all(x in params for x in ["en", "enn"])
-        or all(x in params for x in ["cke", "cken"])
+        all(x in params for x in ["a", "an"])
+        or all(x in params for x in ["r", "rn"])
+        or all(x in params for x in ["e", "en"])
+        or all(x in params for x in ["c", "cn"])
     ):
         raise ValueError(
             "All signals are mutually exclusive with their negated version"
@@ -440,19 +440,17 @@ def get_iob_clk_ports(params: str = None):
         )
     ]
 
-    for port, descr in [
-        ("cke", "Clock enable"),
-        ("cken", "Active-low clock enable"),
-        ("arst", "Asynchronous active-high reset"),
-        ("arstn", "Asynchronous active-low reset"),
-        ("rst", "Synchronous active-high reset"),
-        ("rstn", "Synchronous active-low reset"),
-        ("en", "Enable"),
-        ("enn", "Active-low enable"),
+    for param, port, descr in [
+        ("c",  "cke",    "Clock enable"),
+        ("cn", "cke_n",  "Active-low clock enable"),
+        ("a",  "arst",   "Asynchronous active-high reset"),
+        ("an", "arst_n", "Asynchronous active-low reset"),
+        ("r",  "rst",    "Synchronous active-high reset"),
+        ("rn", "rst_n",  "Synchronous active-low reset"),
+        ("e",  "en",     "Enable"),
+        ("en", "en_n",   "Active-low enable"),
     ]:
-        if port in params:
-            if "low" in descr:
-                port = port[:-1] + "_n"
+        if param in params:
             ports.append(
                 iob_signal(
                     name=port + "_o",

--- a/py2hwsw/scripts/io_gen.py
+++ b/py2hwsw/scripts/io_gen.py
@@ -41,7 +41,8 @@ def generate_ports(core):
 
         for signal_idx, signal in enumerate(port.signals):
             if isinstance(signal, iob_signal):
-                lines.append("    " + signal.get_verilog_port())
+                if signal.get_verilog_port():
+                    lines.append("    " + signal.get_verilog_port())
 
         # Close ifdef if conditional interface
         if port.if_defined or port.if_not_defined:

--- a/py2hwsw/scripts/iob_base.py
+++ b/py2hwsw/scripts/iob_base.py
@@ -488,15 +488,15 @@ def validate_verilog_const(value: str, direction: str):
         _bases = {"b":"01","d":"0123456789", "h":"0123456789abcdef"}
         _, _v = value.split("'")
         if _v[0] not in _bases:
-            fail_with_msg(f"Invalid base for wire '{wire_name}'! Expected b, d or h, got {_v[0]}.")
+            fail_with_msg(f"Invalid base for wire '{value}'! Expected b, d or h, got {_v[0]}.")
         elif not all(c in _bases[_v[0]] for c in _v[1:]):
-            fail_with_msg(f"Invalid value for wire '{wire_name}'! Expected [{_bases[_v[0]]}], got {_v[1:]}.")
+            fail_with_msg(f"Invalid value for wire '{value}'! Expected [{_bases[_v[0]]}], got {_v[1:]}.")
     elif direction == "output":
         assert (
             "z" in value.lower(),
-            f"If not connected, output wire '{wire_name}' must be a high impedance value (z)!"
+            f"If not connected, output wire '{value}' must be a high impedance value (z)!"
         )
     else:
         fail_with_msg(
-            f"Invalid direction '{direction}' for wire '{wire_name}'! Expected input or output."
+            f"Invalid direction '{direction}' for wire '{value}'! Expected input or output."
         )

--- a/py2hwsw/scripts/iob_base.py
+++ b/py2hwsw/scripts/iob_base.py
@@ -479,3 +479,18 @@ def assert_attributes(
     for arg in kwargs:
         if arg not in inspect.signature(func).parameters:
             fail_with_msg(error_msg.replace("[func]", str(func)).replace("[arg]", arg))
+
+def validate_verilog_const(value: str, direction: str):
+    """Validate if constant is a valid Verilog constant and if it is compatible with the direction
+    :param value: constant to validate
+    :param direction: direction of the constant (input or output)"""
+    _bases = {"b":"01z","d":"0123456789z", "h":"0123456789abcdefz"}
+    _, _v = value.split("'")
+    if _v[0] not in _bases:
+        fail_with_msg(f"Invalid base for wire '{wire_name}'! Expected b, d or h, got {_v[0]}.")
+    elif not all(c in _bases[_v[0]] for c in _v[1:]):
+        fail_with_msg(f"Invalid value for wire '{wire_name}'! Expected [{_bases[_v[0]]}], got {_v[1:]}.")
+    if "z" in _v[1:] and direction == "input":
+        fail_with_msg(f"Invalid value for wire '{wire_name}'! Cannot have high impedance on input.")
+    if not all(c == "z" for c in _v[1:]) and direction == "output":
+        fail_with_msg(f"Invalid value for wire '{wire_name}'! Output cannot be driven.")

--- a/py2hwsw/scripts/iob_base.py
+++ b/py2hwsw/scripts/iob_base.py
@@ -484,13 +484,19 @@ def validate_verilog_const(value: str, direction: str):
     """Validate if constant is a valid Verilog constant and if it is compatible with the direction
     :param value: constant to validate
     :param direction: direction of the constant (input or output)"""
-    _bases = {"b":"01z","d":"0123456789z", "h":"0123456789abcdefz"}
-    _, _v = value.split("'")
-    if _v[0] not in _bases:
-        fail_with_msg(f"Invalid base for wire '{wire_name}'! Expected b, d or h, got {_v[0]}.")
-    elif not all(c in _bases[_v[0]] for c in _v[1:]):
-        fail_with_msg(f"Invalid value for wire '{wire_name}'! Expected [{_bases[_v[0]]}], got {_v[1:]}.")
-    if "z" in _v[1:] and direction == "input":
-        fail_with_msg(f"Invalid value for wire '{wire_name}'! Cannot have high impedance on input.")
-    if not all(c == "z" for c in _v[1:]) and direction == "output":
-        fail_with_msg(f"Invalid value for wire '{wire_name}'! Output cannot be driven.")
+    if direction == "input":
+        _bases = {"b":"01","d":"0123456789", "h":"0123456789abcdef"}
+        _, _v = value.split("'")
+        if _v[0] not in _bases:
+            fail_with_msg(f"Invalid base for wire '{wire_name}'! Expected b, d or h, got {_v[0]}.")
+        elif not all(c in _bases[_v[0]] for c in _v[1:]):
+            fail_with_msg(f"Invalid value for wire '{wire_name}'! Expected [{_bases[_v[0]]}], got {_v[1:]}.")
+    elif direction == "output":
+        assert (
+            "z" in value.lower(),
+            f"If not connected, output wire '{wire_name}' must be a high impedance value (z)!"
+        )
+    else:
+        fail_with_msg(
+            f"Invalid direction '{direction}' for wire '{wire_name}'! Expected input or output."
+        )

--- a/py2hwsw/scripts/iob_base.py
+++ b/py2hwsw/scripts/iob_base.py
@@ -485,6 +485,8 @@ def validate_verilog_const(value: str, direction: str):
     :param value: constant to validate
     :param direction: direction of the constant (input or output)"""
     if direction == "input":
+        assert "'" in value, f"{iob_colors.FAIL}Invalid format for wire '{value}'! Expected <width>'<base><value>', got {value}.{iob_colors.ENDC}"
+        
         _bases = {"b":"01","d":"0123456789", "h":"0123456789abcdef"}
         _, _v = value.split("'")
         if _v[0] not in _bases:
@@ -492,10 +494,8 @@ def validate_verilog_const(value: str, direction: str):
         elif not all(c in _bases[_v[0]] for c in _v[1:]):
             fail_with_msg(f"Invalid value for wire '{value}'! Expected [{_bases[_v[0]]}], got {_v[1:]}.")
     elif direction == "output":
-        assert (
-            "z" in value.lower(),
-            f"If not connected, output wire '{value}' must be a high impedance value (z)!"
-        )
+        assert "z" in value.lower(), f"{iob_colors.FAIL}If not connected, output wire '{value}' must be a high impedance value (z)!{iob_colors.ENDC}"
+        
     else:
         fail_with_msg(
             f"Invalid direction '{direction}' for wire '{value}'! Expected input or output."

--- a/py2hwsw/scripts/iob_comb.py
+++ b/py2hwsw/scripts/iob_comb.py
@@ -16,7 +16,7 @@ class iob_comb(iob_snippet):
     """Class to represent a Verilog combinatory circuit in an iob module"""
 
     code: str = ""
-    clk_if: str = "cke_arst"
+    clk_if: str = "c_a"
 
     def __post_init__(self):
         """Wrap verilog code with the always block"""
@@ -124,15 +124,15 @@ class iob_comb(iob_snippet):
                             {"name": f"{signal.name}_en", "descr": f"{signal.name} enable", "width": 1, "isvar": True}
                         )
                         bit_slices.append(f"en_i:{signal.name}_en")
-                        port_params = port_params + "_en"
+                        port_params = port_params + "_e"
                     if any(reg_signal == "_rst" for reg_signal in signal.reg_signals):
                         _reg_signals.append(
                             {"name": f"{signal.name}_rst", "descr": f"{signal.name} reset", "width": 1, "isvar": True}
                         )
                         bit_slices.append(f"rst_i:{signal.name}_rst")
-                        port_params = port_params + "_rst"
+                        port_params = port_params + "_r"
 
-                    if any(x in port_params for x in ["_rst", "_en"]):
+                    if any(x in port_params for x in ["_r", "_e"]):
                         if not any(
                             wire.name == f"{signal.name}_reg_signals"
                             for wire in core.wires

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -615,7 +615,7 @@ class iob_core(iob_module, iob_instance):
             else:
                 fail_with_msg(f"Invalid connection value: {connection_value}")
 
-            if "'" in wire_name:
+            if "'" in wire_name or wire_name.lower() == "z":
                 wire = wire_name
             else:
                 wire = find_obj_in_list(instantiator.wires, wire_name) or find_obj_in_list(instantiator.ports, wire_name)

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -616,15 +616,6 @@ class iob_core(iob_module, iob_instance):
                 fail_with_msg(f"Invalid connection value: {connection_value}")
 
             if "'" in wire_name:
-                validate_verilog_const(wire_name, port.direction)
-                if not isintsance(port.signals,list):
-                    fail_with_msg(
-                        f"Port '{port.name}' signals must be a list of lenght 1 to connect to constant value '{wire_name}'"
-                    )
-                elif len(port.signals) != 1:
-                    fail_with_msg(
-                        f"Port '{port.name}' signals must be a list of lenght 1 to connect to constant value '{wire_name}'"
-                    )
                 wire = wire_name
             else:
                 wire = find_obj_in_list(instantiator.wires, wire_name) or find_obj_in_list(instantiator.ports, wire_name)

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -40,7 +40,6 @@ from iob_base import (
     nix_permission_hack,
     add_traceback_msg,
     debug,
-    validate_verilog_const,
 )
 from iob_license import iob_license, update_license
 import sw_tools

--- a/py2hwsw/scripts/iob_port.py
+++ b/py2hwsw/scripts/iob_port.py
@@ -5,6 +5,7 @@
 from dataclasses import dataclass, field
 
 import if_gen
+import iob_colors
 from iob_wire import iob_wire, replace_duplicate_signals_by_references
 from iob_base import (
     convert_dict2obj_list,
@@ -134,11 +135,11 @@ class iob_port(iob_wire):
                     fail_with_msg(
                         """{iob_colors.FAIL}Port '{self.name}' has different number of signals compared to external connection '{wire.name}'!
 Port '{self.name}' has the following signals:
-{newlinechar.join("- " + get_real_signal(port).name for port in self.signals)}
+{newlinechar.join("- " + signal.name for signal in self.signals)}
 
-External connection '{get_real_signal(wire).name}' has the following signals:
-{newlinechar.join("- " + get_real_signal(port).name for port in wire.signals)}
-{iob_colors.ENDC}"""
+External connection '{wire.name}' has the following signals:
+{newlinechar.join("- " + signal.name for signal in wire.signals)}
+{iob_colors.ENDC}""",
                         ValueError,
                     )
             elif len(self.signals) != len(wire.signals):
@@ -146,11 +147,11 @@ External connection '{get_real_signal(wire).name}' has the following signals:
                 fail_with_msg(
                     f"""{iob_colors.FAIL}Port '{self.name}' has different number of signals compared to external connection '{wire.name}'!
 Port '{self.name}' has the following signals:
-{newlinechar.join("- " + get_real_signal(port).name for port in self.signals)}
+{newlinechar.join("- " + signal.name for signal in self.signals)}
 
-External connection '{get_real_signal(wire).name}' has the following signals:
-{newlinechar.join("- " + get_real_signal(port).name for port in wire.signals)}
-{iob_colors.ENDC}"""
+External connection '{wire.name}' has the following signals:
+{newlinechar.join("- " + signal.name for signal in wire.signals)}
+{iob_colors.ENDC}""",
                     ValueError,
                 )
         else:

--- a/py2hwsw/scripts/iob_signal.py
+++ b/py2hwsw/scripts/iob_signal.py
@@ -42,6 +42,8 @@ class iob_signal:
 
     def get_verilog_wire(self):
         """Generate a verilog wire string from this signal"""
+        if "'" in self.name or self.name.lower() == "z":
+            return None
         wire_type = "reg" if self.isvar else "wire"
         width_str = "" if self.get_width_int() == 1 else f"[{self.width}-1:0] "
         return f"{wire_type} {width_str}{self.name};\n"
@@ -52,6 +54,8 @@ class iob_signal:
 
     def get_verilog_port(self, comma=True):
         """Generate a verilog port string from this signal"""
+        if "'" in self.name or self.name.lower() == "z":
+            return None
         self.assert_direction()
         comma_char = "," if comma else ""
         port_type = " reg" if self.isvar else ""

--- a/py2hwsw/scripts/wire_gen.py
+++ b/py2hwsw/scripts/wire_gen.py
@@ -27,7 +27,8 @@ def generate_wires(core):
         signals_code = ""
         for signal in wire.signals:
             if isinstance(signal, iob_signal):
-                signals_code += "    " + signal.get_verilog_wire()
+                if signal.get_verilog_wire():
+                    signals_code += "    " + signal.get_verilog_wire()
         if signals_code:
             # Add description for the wire if it is not the default one
             if wire.descr != "" and wire.descr != "Default description":


### PR DESCRIPTION
- `iob_clk` and `iob_reg` parameters change:
    n, cke[n], arst[n], rst[n], en[n] --> n, c[n], a[n], r[n], e[n]

- `iob_reg` names updated e.g. `iob_reg_caer_r --> iob_reg_car`

- The verification of connections is moved from `block_gen.py` to `iob_port.py`

- Ports can now be connected to constants (inputs) or be left unconnected (outputs)
    E.g of direct connection to port with only one signal: 
    `"<input_port_name>": "32'd42"` or `"<output_port_name>": "z"`
   To connect constants to a port with multiple signals, a wire must be created with all the signals (or references) to be connected to the port where the constant value is the signal name. Wire e.g.:
    ```
    {"name": "wire_name",
     "signals": [
        {"name": "signal0"},
        {"name": "signal1"},
        {"name": "32'd35"}, # Constant value in the position of the intended input port; resulting verilog: .port2(32'd35)
        {"name": "z"}, # High impedance in the position of the intended output port; resulting verilog: .port3()
        ...
        {"name": "signal"},
    ]
    }
    ```