### PR TITLE
fix(csrs): use instantiator version by default

### DIFF
--- a/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
+++ b/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
@@ -47,13 +47,19 @@ def setup(py_params_dict):
         }
         py_params_dict["dest_dir"] = "dummy_dest"
 
+    # by default use same version as instantiator
+    # use py2hwsw version as fallback
+    default_version = py_params_dict["py2hwsw_version"]
+    if "instantiator" in py_params_dict:
+        default_version = py_params_dict["instantiator"].get("version", default_version)
+
     params = {
         # Use the same name as instantiator + the suffix "_csrs"
         "name": py_params_dict["instantiator"]["name"] + "_csrs",
         # Destination directory
         "dest_dir": py_params_dict["dest_dir"],
-        # Version of the CSRs module (by default use same version as py2hwsw)
-        "version": py_params_dict["py2hwsw_version"],
+        # Version of the CSRs module (by default use instantiator version, py2hwsw as fallback)
+        "version": default_version,
         # Type of interface for CSR bus
         "csr_if": "iob",
         # List of Control Status Registers (CSRs)

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
@@ -537,7 +537,7 @@ class csr_gen:
                         {
                             "name": f"{name}_ready_i",
                             "width": 1,
-                        }
+                        },
                     ]
                     port_has_inputs = True
                     port_has_outputs = True


### PR DESCRIPTION
- update csrs to use instantiator version by default, fallback do py2hwsw version.
- With this change, a core with `"version": "ab.cd"` that instantiates a `iob_csrs` subblock, generates a `iob_[CORE]_csrs` with `"version": "ab.cd"`.
- Previously, the `iob_[CORE]_csrs` had `"version": PY2HWSW_VERSION`