### PR TITLE
fix(csrs): improve generated csrs logic

### DIFF
--- a/py2hwsw/lib/hardware/basic_tests/iob_csrs_demo/iob_csrs_demo.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_csrs_demo/iob_csrs_demo.py
@@ -55,7 +55,7 @@ def setup(py_params_dict):
                 "signals": [
                     {"name": "single_read_write_wrrd_o", "width": 1},
                     {"name": "single_read_write_wrrd_i", "width": 1},
-                    {"name": "single_read_write_wrrd_wen", "width": 1},
+                    {"name": "single_read_write_wrrd_wstrb", "width": 1},
                 ],
             },
             {
@@ -64,7 +64,7 @@ def setup(py_params_dict):
                 "signals": [
                     {"name": "multi_read_write_wrrd_o", "width": 23},
                     {"name": "multi_read_write_wrrd_i", "width": 23},
-                    {"name": "multi_read_write_wrrd_wen", "width": 1},
+                    {"name": "multi_read_write_wrrd_wstrb", "width": 3},
                 ],
             },
             # Regarray wires

--- a/py2hwsw/lib/hardware/basic_tests/iob_csrs_demo/iob_csrs_demo.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_csrs_demo/iob_csrs_demo.py
@@ -58,6 +58,15 @@ def setup(py_params_dict):
                     {"name": "single_read_write_wrrd_wen", "width": 1},
                 ],
             },
+            {
+                "name": "multi_read_write",
+                "descr": "",
+                "signals": [
+                    {"name": "multi_read_write_wrrd_o", "width": 23},
+                    {"name": "multi_read_write_wrrd_i", "width": 23},
+                    {"name": "multi_read_write_wrrd_wen", "width": 1},
+                ],
+            },
             # Regarray wires
             {
                 "name": "regarray_write",
@@ -569,6 +578,14 @@ def setup(py_params_dict):
                                 "rst_val": 0,
                                 "log2n_items": 0,
                             },
+                            {
+                                "name": "multi_read_write",
+                                "descr": "multi read write register",
+                                "mode": "RW",
+                                "n_bits": 23,
+                                "rst_val": 0,
+                                "log2n_items": 0,
+                            },
                         ],
                     },
                     # Reg arrays
@@ -778,6 +795,7 @@ def setup(py_params_dict):
                     "single_write_o": "single_write",
                     "single_read_i": "single_read",
                     "single_read_write_io": "single_read_write",
+                    "multi_read_write_io": "multi_read_write",
                     # regarray
                     "regarray_write_read_io": "regarray_write",
                     "regarray_read_write_io": "regarray_read",

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/fifos.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/fifos.py
@@ -640,7 +640,7 @@ def create_fifo_instance(attributes_dict, csr_ref):
             {
                 "verilog_code": f"""
    // Connect FIFO level status to CSRs
-   assign {fifo_name}_level = {fifo_name}_current_level_o;
+   assign {fifo_name}_level_wdata = {fifo_name}_current_level_o;
 
 """,
             }
@@ -650,7 +650,7 @@ def create_fifo_instance(attributes_dict, csr_ref):
             {
                 "verilog_code": f"""
    // Generate interrupt signal
-   assign {fifo_name}_interrupt_o ={fifo_name}_current_level_o >= {fifo_name}_thresh;
+   assign {fifo_name}_interrupt_o ={fifo_name}_current_level_o >= {fifo_name}_thresh_rdata;
 """,
             }
         )


### PR DESCRIPTION
- RW regs with wen width 1
- remove sufix `_i` from `byte_aligned` internal wires
- fix R register logic: remove unnecessary register enable
- fix RW register logic register enable on CSR write access or `wen` from core
- fix auto register csrs port names
- add example of RW register with multiple bits (to show correct `wen` generation)