### PR TITLE
iob_comb improvements and fixes

### DIFF
--- a/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
+++ b/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
@@ -19,6 +19,8 @@ def setup(py_params_dict):
 
     reset_polarity = getattr(iob_globals(), "reset_polarity", "positive")
 
+    clk_port_params = port_params["clk_en_rst_s"]
+
     if reset_polarity != "positive":
         port_params["clk_en_rst_s"] = port_params["clk_en_rst_s"].replace("a", "an")
 
@@ -100,7 +102,7 @@ def setup(py_params_dict):
                 "name": "clk_en_rst_s",
                 "signals": {
                     "type": "iob_clk",
-                    "params": port_params["clk_en_rst_s"],
+                    "params": clk_port_params,
                 },
                 "descr": "Clock, clock enable and reset",
             },


### PR DESCRIPTION
If '_nxt' signal is used in comb but is not driven, "signal_nxt = signal" is added to always block; Resolves https://github.com/IObundle/py2hwsw/issues/275

User can choose clock that connects to iob_comb with the clk_if attribute using the syntax: "[prefix]clk_i:[params]"
If <params> is omitted, the params are inherited from the clk interface. If "[prefix]clk_i:" is omitted, the clk interface without a prefix is selected. Resloves https://github.com/IObundle/py2hwsw/issues/272

Fix bug where iob_reg would not create arst_n_i port.