### PR TITLE
feat(setup): split py2hwsw core setup into 2 stages: object construction and build dir generation 

### DIFF
--- a/py2hwsw/hardware/fpga/quartus/iob_arria10_gx_dk/iob_generic_arria10_gx_dk/iob_generic_arria10_gx_dk.py
+++ b/py2hwsw/hardware/fpga/quartus/iob_arria10_gx_dk/iob_generic_arria10_gx_dk/iob_generic_arria10_gx_dk.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_arria10_gx_dk",
+        "name": py_params_dict["issuer"]["name"] + "_iob_arria10_gx_dk",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/quartus/iob_cyclonev_gt_dk/iob_generic_cyclonev_gt_dk/iob_generic_cyclonev_gt_dk.py
+++ b/py2hwsw/hardware/fpga/quartus/iob_cyclonev_gt_dk/iob_generic_cyclonev_gt_dk/iob_generic_cyclonev_gt_dk.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_cyclonev_gt_dk",
+        "name": py_params_dict["issuer"]["name"] + "_iob_cyclonev_gt_dk",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/quartus/iob_de10_lite/iob_generic_de10_lite/iob_generic_de10_lite.py
+++ b/py2hwsw/hardware/fpga/quartus/iob_de10_lite/iob_generic_de10_lite/iob_generic_de10_lite.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_de10_lite",
+        "name": py_params_dict["issuer"]["name"] + "_iob_de10_lite",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/quartus/iob_dk_dev_10cx220_a/iob_generic_dk_dev_10cx220_a/iob_generic_dk_dev_10cx220_a.py
+++ b/py2hwsw/hardware/fpga/quartus/iob_dk_dev_10cx220_a/iob_generic_dk_dev_10cx220_a/iob_generic_dk_dev_10cx220_a.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_dk_dev_10cx220_a",
+        "name": py_params_dict["issuer"]["name"] + "_iob_dk_dev_10cx220_a",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/quartus/iob_dk_dev_agf014e2es/iob_generic_dk_dev_agf014e2es/iob_generic_dk_dev_agf014e2es.py
+++ b/py2hwsw/hardware/fpga/quartus/iob_dk_dev_agf014e2es/iob_generic_dk_dev_agf014e2es/iob_generic_dk_dev_agf014e2es.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_dk_dev_agf014e2es",
+        "name": py_params_dict["issuer"]["name"] + "_iob_dk_dev_agf014e2es",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/vivado/iob_ac701/iob_generic_ac701/iob_generic_ac701.py
+++ b/py2hwsw/hardware/fpga/vivado/iob_ac701/iob_generic_ac701/iob_generic_ac701.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_ac701",
+        "name": py_params_dict["issuer"]["name"] + "_iob_ac701",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/vivado/iob_aes_ku040_db_g/iob_generic_aes_ku040_db_g/iob_generic_aes_ku040_db_g.py
+++ b/py2hwsw/hardware/fpga/vivado/iob_aes_ku040_db_g/iob_generic_aes_ku040_db_g/iob_generic_aes_ku040_db_g.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_aes_ku040_db_g",
+        "name": py_params_dict["issuer"]["name"] + "_iob_aes_ku040_db_g",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/vivado/iob_arty_s7_50/iob_generic_arty_s7_50/iob_generic_arty_s7_50.py
+++ b/py2hwsw/hardware/fpga/vivado/iob_arty_s7_50/iob_generic_arty_s7_50/iob_generic_arty_s7_50.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_arty_s7_50",
+        "name": py_params_dict["issuer"]["name"] + "_iob_arty_s7_50",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/vivado/iob_au20p/iob_generic_au20p/iob_generic_au20p.py
+++ b/py2hwsw/hardware/fpga/vivado/iob_au20p/iob_generic_au20p/iob_generic_au20p.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_au20p",
+        "name": py_params_dict["issuer"]["name"] + "_iob_au20p",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/vivado/iob_basys3/iob_generic_basys3/iob_generic_basys3.py
+++ b/py2hwsw/hardware/fpga/vivado/iob_basys3/iob_generic_basys3/iob_generic_basys3.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_basys3",
+        "name": py_params_dict["issuer"]["name"] + "_iob_basys3",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/vivado/iob_ku15p/iob_generic_ku15p/iob_generic_ku15p.py
+++ b/py2hwsw/hardware/fpga/vivado/iob_ku15p/iob_generic_ku15p/iob_generic_ku15p.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_ku15p",
+        "name": py_params_dict["issuer"]["name"] + "_iob_ku15p",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/vivado/iob_xem8320_au25p/iob_generic_xem8320_au25p/iob_generic_xem8320_au25p.py
+++ b/py2hwsw/hardware/fpga/vivado/iob_xem8320_au25p/iob_generic_xem8320_au25p/iob_generic_xem8320_au25p.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_xem8320_au25p",
+        "name": py_params_dict["issuer"]["name"] + "_iob_xem8320_au25p",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/fpga/vivado/iob_zybo_z7/iob_generic_zybo_z7/iob_generic_zybo_z7.py
+++ b/py2hwsw/hardware/fpga/vivado/iob_zybo_z7/iob_generic_zybo_z7/iob_generic_zybo_z7.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_iob_zybo_z7",
+        "name": py_params_dict["issuer"]["name"] + "_iob_zybo_z7",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/hardware/simulation/src/iob_sim.py
+++ b/py2hwsw/hardware/simulation/src/iob_sim.py
@@ -5,7 +5,7 @@
 
 def setup(py_params_dict):
     attributes_dict = {
-        "name": py_params_dict["instantiator"]["name"] + "_sim",
+        "name": py_params_dict["issuer"]["name"] + "_sim",
         "generate_hw": False,
         "confs": [
             {

--- a/py2hwsw/lib/hardware/clocks_resets/iob_pulse_gen/iob_pulse_gen_tester/iob_pulse_gen_tester.py
+++ b/py2hwsw/lib/hardware/clocks_resets/iob_pulse_gen/iob_pulse_gen_tester/iob_pulse_gen_tester.py
@@ -41,7 +41,7 @@ def setup(py_params_dict):
                 "subblocks": [
                     {
                         # Instantiate SUT (usually iob_system or a child of it)
-                        "core_name": py_params_dict["instantiator"]["original_name"],
+                        "core_name": py_params_dict["issuer"]["original_name"],
                         "instance_name": "pulse_gen_uut",
                         "instance_description": "Unit Under Test (UUT) to be verified by this tester.",
                         "parameters": {

--- a/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
+++ b/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
@@ -45,24 +45,24 @@ def setup(py_params_dict):
             }
         ]
         py_params_dict["build_dir"] = "dummy_folder"
-        py_params_dict["instantiator"] = {
+        py_params_dict["issuer"] = {
             "name": "iob",
             "confs": [],
         }
         py_params_dict["dest_dir"] = "dummy_dest"
 
-    # by default use same version as instantiator
+    # by default use same version as issuer
     # use py2hwsw version as fallback
     default_version = py_params_dict["py2hwsw_version"]
-    if "instantiator" in py_params_dict:
-        default_version = py_params_dict["instantiator"].get("version", default_version)
+    if "issuer" in py_params_dict:
+        default_version = py_params_dict["issuer"].get("version", default_version)
 
     params = {
-        # Use the same name as instantiator + the suffix "_csrs"
-        "name": py_params_dict["instantiator"]["name"] + "_csrs",
+        # Use the same name as issuer + the suffix "_csrs"
+        "name": py_params_dict["issuer"]["name"] + "_csrs",
         # Destination directory
         "dest_dir": py_params_dict["dest_dir"],
-        # Version of the CSRs module (by default use instantiator version, py2hwsw as fallback)
+        # Version of the CSRs module (by default use issuer version, py2hwsw as fallback)
         "version": default_version,
         # Type of interface for CSR bus
         "csr_if": "iob",
@@ -94,7 +94,7 @@ def setup(py_params_dict):
     if params["csr_if"] == "axi":
         csr_if_params = {"AXI_ID_W": 1, "AXI_LEN_W": 8}
 
-    # Copy instantiator confs but skip ADDR_W and CSR params
+    # Copy issuer confs but skip ADDR_W and CSR params
     confs = [
         {
             "name": "ADDR_W",
@@ -105,14 +105,14 @@ def setup(py_params_dict):
             "descr": "Address bus width",
         },
     ]
-    for conf in py_params_dict["instantiator"].get("confs", []):
+    for conf in py_params_dict["issuer"].get("confs", []):
         if conf["name"] == "ADDR_W" or conf["name"] in csr_if_params:
             continue
         confs.append(conf)
 
     # Append DATA_W parameter if not already present
     if "DATA_W" not in [
-        conf["name"] for conf in py_params_dict["instantiator"].get("confs", [])
+        conf["name"] for conf in py_params_dict["issuer"].get("confs", [])
     ]:
         confs.append(
             {

--- a/py2hwsw/lib/hardware/memories/iob_memwrapper/iob_memwrapper.py
+++ b/py2hwsw/lib/hardware/memories/iob_memwrapper/iob_memwrapper.py
@@ -12,12 +12,12 @@ from iob_core import find_module_setup_dir
 
 def setup(py_params_dict):
     """Memory wrapper core. Inteended to be used as a superblock of other cores.
-    Required memories are automatically generated based on the ports of the instantiator (subblock).
+    Required memories are automatically generated based on the ports of the issuer (subblock).
     """
     # Check if should create a demonstation of this core
     if py_params_dict.get("demo", False):
         py_params_dict["mem_if_names"] = []
-        py_params_dict["instantiator"] = {
+        py_params_dict["issuer"] = {
             "original_name": "iob_core",
             "name": "iob",
             "confs": [],
@@ -26,7 +26,7 @@ def setup(py_params_dict):
 
     # List of supported memory interfaces (usually taken from if_gen.py)
     mem_if_names = py_params_dict["mem_if_names"]
-    attrs = py_params_dict["instantiator"]
+    attrs = py_params_dict["issuer"]
 
     attributes_dict = {
         "name": f"{attrs['name']}_mwrap",

--- a/py2hwsw/lib/iob_system/hardware/fpga/quartus/iob_cyclonev_gt_dk/iob_system_iob_cyclonev_gt_dk/iob_system_iob_cyclonev_gt_dk.py
+++ b/py2hwsw/lib/iob_system/hardware/fpga/quartus/iob_cyclonev_gt_dk/iob_system_iob_cyclonev_gt_dk/iob_system_iob_cyclonev_gt_dk.py
@@ -266,8 +266,8 @@ def setup(py_params_dict):
     #
     attributes_dict["subblocks"] = [
         {
-            "core_name": py_params_dict["instantiator"]["original_name"],
-            "instance_name": py_params_dict["instantiator"]["original_name"],
+            "core_name": py_params_dict["issuer"]["original_name"],
+            "instance_name": py_params_dict["issuer"]["original_name"],
             "instance_description": "IOb-SoC memory wrapper",
             "parameters": {
                 "AXI_ID_W": "AXI_ID_W",

--- a/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_aes_ku040_db_g/iob_system_iob_aes_ku040_db_g/iob_system_iob_aes_ku040_db_g.py
+++ b/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_aes_ku040_db_g/iob_system_iob_aes_ku040_db_g/iob_system_iob_aes_ku040_db_g.py
@@ -293,8 +293,8 @@ def setup(py_params_dict):
     attributes_dict["subblocks"] = [
         {
             # IOb-SoC Memory Wrapper
-            "core_name": py_params_dict["instantiator"]["original_name"],
-            "instance_name": py_params_dict["instantiator"]["original_name"],
+            "core_name": py_params_dict["issuer"]["original_name"],
+            "instance_name": py_params_dict["issuer"]["original_name"],
             "instance_description": "IOb-SoC instance",
             "parameters": {
                 "AXI_ID_W": "AXI_ID_W",

--- a/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_basys3/iob_system_iob_basys3/iob_system_iob_basys3.py
+++ b/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_basys3/iob_system_iob_basys3/iob_system_iob_basys3.py
@@ -135,8 +135,8 @@ def setup(py_params_dict):
     attributes_dict["subblocks"] = [
         {
             # IOb-SoC Memory Wrapper
-            "core_name": py_params_dict["instantiator"]["original_name"],
-            "instance_name": py_params_dict["instantiator"]["original_name"],
+            "core_name": py_params_dict["issuer"]["original_name"],
+            "instance_name": py_params_dict["issuer"]["original_name"],
             "instance_description": "IOb-SoC instance",
             "parameters": {
                 "AXI_ID_W": "AXI_ID_W",

--- a/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_zybo_z7/iob_system_iob_zybo_z7/iob_system_iob_zybo_z7.py
+++ b/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_zybo_z7/iob_system_iob_zybo_z7/iob_system_iob_zybo_z7.py
@@ -352,8 +352,8 @@ def setup(py_params_dict):
     attributes_dict["subblocks"] = [
         {
             # Memory Wrapper
-            "core_name": py_params_dict["instantiator"]["original_name"],
-            "instance_name": py_params_dict["instantiator"]["original_name"],
+            "core_name": py_params_dict["issuer"]["original_name"],
+            "instance_name": py_params_dict["issuer"]["original_name"],
             "instance_description": "IOb-SoC instance",
             "parameters": {
                 "AXI_ID_W": "AXI_ID_W",

--- a/py2hwsw/lib/iob_system/hardware/simulation/iob_system_sim/iob_system_sim.py
+++ b/py2hwsw/lib/iob_system/hardware/simulation/iob_system_sim/iob_system_sim.py
@@ -220,8 +220,8 @@ def setup(py_params_dict):
     #
     attributes_dict["subblocks"] = [
         {
-            "core_name": py_params_dict["instantiator"]["original_name"],
-            "instance_name": py_params_dict["instantiator"]["original_name"],
+            "core_name": py_params_dict["issuer"]["original_name"],
+            "instance_name": py_params_dict["issuer"]["original_name"],
             "instance_description": "IOb-SoC memory wrapper",
             "parameters": {
                 "AXI_ID_W": "AXI_ID_W",

--- a/py2hwsw/lib/iob_system/iob_system_tester/iob_system_tester.py
+++ b/py2hwsw/lib/iob_system/iob_system_tester/iob_system_tester.py
@@ -45,7 +45,7 @@ def setup(py_params_dict):
                 "subblocks": [
                     {
                         # Instantiate SUT (usually iob_system or a child of it)
-                        "core_name": py_params_dict["instantiator"]["original_name"],
+                        "core_name": py_params_dict["issuer"]["original_name"],
                         "instance_name": "SUT",
                         "instance_description": "System Under Test (SUT) to be verified by this tester.",
                         # "is_peripheral": True,  # Only applies if SUT has CSRs (via regfileif).

--- a/py2hwsw/py2hwsw_document/document/tsrc/special_cases.tex
+++ b/py2hwsw/py2hwsw_document/document/tsrc/special_cases.tex
@@ -9,7 +9,7 @@ The following list describes the cores don't rely solely on the standard interfa
 
 \begin{itemize}
 \item \textbf{iob\_system}: This core uses the `is\_system` attribute to enable an internal py2hwsw method that automatically fixes the address widths of the cbus interfaces of the system's peripherals.
-\item \textbf{iob\_csrs}: The py2hwsw tool contains an internal method to automatically search for the "iob\_csrs" subblock and insert a "\textless prefix\textgreater \_cbus\_s" port on the instantiator core of this subblock. It then connects this newly created "\textless prefix\textgreater \_cbus\_s" port of the instantiator core to the iob\_csrs "control\_if\_s" port. The '\textless prefix\textgreater ' is replaced by instance name of iob\_csrs subblock.
+\item \textbf{iob\_csrs}: The py2hwsw tool contains an internal method to automatically search for the "iob\_csrs" subblock and insert a "\textless prefix\textgreater \_cbus\_s" port on the issuer core of this subblock. It then connects this newly created "\textless prefix\textgreater \_cbus\_s" port of the issuer core to the iob\_csrs "control\_if\_s" port. The '\textless prefix\textgreater ' is replaced by instance name of iob\_csrs subblock.
 \end{itemize}
 
 

--- a/py2hwsw/py2hwsw_document/document/tsrc/standard_interfaces.tex
+++ b/py2hwsw/py2hwsw_document/document/tsrc/standard_interfaces.tex
@@ -18,7 +18,7 @@ This allows the user to use external tools to generate cores in JSON format.
 % Python parameters
 %
 
-The \textit{Python Parameters} received by the core's "setup" function is a dictionary containing both parameters passed by its instantiator and standard parameters passed by Py2HWSW.
+The \textit{Python Parameters} received by the core's "setup" function is a dictionary containing both parameters passed by its issuer and standard parameters passed by Py2HWSW.
 Each key, value pair in the dictionary is a \textit{Python Parameter}.
 The value of the python parameter may be of any data type.
 

--- a/py2hwsw/scripts/doc_gen.py
+++ b/py2hwsw/scripts/doc_gen.py
@@ -80,7 +80,7 @@ def generate_tex_py2hwsw_standard_py_params(out_dir):
         [
             "build_dir",
             str,
-            "Build directory of this core. Usually defined by `--build-dir` flag or instantiator.",
+            "Build directory of this core. Usually defined by `--build-dir` flag or issuer.",
         ],
         [
             "py2hwsw_target",
@@ -88,9 +88,9 @@ def generate_tex_py2hwsw_standard_py_params(out_dir):
             "The reason why py2hwsw is invoked. Usually `setup` meaning the Py2HWSW is calling the core's script to obtain information on how to generate the core. May also be other targets like `clean`, `print_attributes`, or `deliver`. These are usually to obtain information about the core for various purposes, but not to generate the build directory.",
         ],
         [
-            "instantiator",
+            "issuer",
             dict,
-            "Core dictionary with attributes of the instantiator core (if any). Allows subblocks to obtain information about their instantiator core.",
+            "Core dictionary with attributes of the issuer core (if any). Allows subblocks to obtain information about their issuer core.",
         ],
         [
             "py2hwsw_version",

--- a/py2hwsw/scripts/iob_block.py
+++ b/py2hwsw/scripts/iob_block.py
@@ -86,7 +86,7 @@ def create_block(
 
     try:
         instance = core.get_core_obj(
-            core_name, instance_name=instance_name, instantiator=core, **kwargs
+            core_name, instance_name=instance_name, issuer=core, **kwargs
         )
 
         getattr(core, blocks_attribute_name).append(instance)

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -304,7 +304,6 @@ class iob_core(iob_module, iob_instance):
         if self.abort_reason:
             return
 
-
     def post_setup(self):
         """Scripts to run at the end of the top module's setup"""
         # Replace Verilog snippet includes
@@ -433,11 +432,12 @@ class iob_core(iob_module, iob_instance):
 
         self.__create_build_dir()
 
-        print(f"DEBUG: generate_build_dir() for {self.name}")
-
-        breakpoint()
         # subblock setup process
         for subblock in self.subblocks:
+            if self.is_superblock:
+                if subblock.original_name == self.instantiator.original_name:
+                    # skip build dir generation for instantiator subblocks
+                    continue
             subblock.generate_build_dir()
 
         # Ensure superblocks are set up only for top module (or wrappers of it)

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -573,11 +573,11 @@ class iob_core(iob_module, iob_instance):
             self.is_system
         ), "Internal error: only iob_system type cores need fixing cbus width"
         for subblock in self.subblocks:
-            for port in subblock.ports:
+            for portmap in subblock.portmap_connections:
                 if (
-                    port.name == "iob_csrs_cbus_s"
-                    and port.interface.type == "iob"
-                    and port.e_connect
+                    portmap.port.name == "iob_csrs_cbus_s"
+                    and portmap.port.interface.type == "iob"
+                    and portmap.e_connect
                 ):
                     # print(
                     #     "DEBUG",
@@ -585,9 +585,9 @@ class iob_core(iob_module, iob_instance):
                     #     port,
                     #     file=sys.stderr,
                     # )
-                    port_width = port.interface.widths["ADDR_W"]
-                    external_wire_prefix = port.e_connect.interface.prefix
-                    port.e_connect_bit_slices = [
+                    port_width = portmap.port.interface.widths["ADDR_W"]
+                    external_wire_prefix = portmap.e_connect.interface.prefix
+                    portmap.e_connect_bit_slices = [
                         f"{external_wire_prefix}iob_addr[{port_width}-1:0]"
                     ]
 

--- a/py2hwsw/scripts/iob_instance.py
+++ b/py2hwsw/scripts/iob_instance.py
@@ -5,7 +5,14 @@
 import copy
 from typing import Dict
 
-from iob_base import iob_base
+from if_gen import mem_if_names
+from iob_base import (
+    iob_base,
+    find_obj_in_list,
+    fail_with_msg,
+    debug,
+)
+from iob_signal import remove_signal_direction_suffixes
 
 
 class iob_instance(iob_base):
@@ -16,6 +23,7 @@ class iob_instance(iob_base):
         *args,
         instance_name: str = None,
         instance_description: str = None,
+        connect: Dict = {},
         parameters: Dict = {},
         if_defined: str = None,
         if_not_defined: str = None,
@@ -37,6 +45,10 @@ class iob_instance(iob_base):
             instance_description or "Default description",
             str,
             descr="Description of the instance",
+        )
+        # Instance portmap connections
+        self.set_default_attribute(
+            "portmap_connections", [], list, descr="Instance portmap connections"
         )
         # Verilog parameter values
         self.set_default_attribute(
@@ -64,6 +76,10 @@ class iob_instance(iob_base):
             bool,
             descr="Select if should intantiate the module inside another Verilog module.",
         )
+
+        issuer = kwargs.get("issuer", None)
+        if issuer and connect:
+            self.connect_instance_ports(connect, issuer)
 
     def __deepcopy__(self, memo):
         """Create a deep copy of this instance:
@@ -96,3 +112,164 @@ class iob_instance(iob_base):
                 setattr(new_obj, attr_name, attr_value)
 
         return new_obj
+
+    def connect_instance_ports(self, connect, issuer):
+        """
+        param connect: External wires to connect to ports of this instance
+                       Key: Port name, Value: Wire name or tuple with wire name and signal bit slices
+                       Tuple has format:
+                       (wire_name, signal_name[bit_start:bit_end], other_signal[bit_start:bit_end], ...)
+        param issuer: Module that is instantiating this instance
+        """
+        # TODO: create portmap from port, connect external
+        # Connect instance ports to external wires
+        for port_name, connection_value in connect.items():
+            port = find_obj_in_list(self.ports, port_name)
+            if not port:
+                fail_with_msg(
+                    f"Port '{port_name}' not found in instance '{self.instance_name}' of module '{issuer.name}'!\n"
+                    f"Available ports:\n- "
+                    + "\n- ".join([port.name for port in self.ports])
+                )
+
+            bit_slices = []
+            if type(connection_value) is str:
+                wire_name = connection_value
+            elif type(connection_value) is tuple:
+                wire_name = connection_value[0]
+                bit_slices = connection_value[1]
+                if type(bit_slices) is not list:
+                    fail_with_msg(
+                        f"Second element of tuple must be a list of bit slices/connections: {connection_value}"
+                    )
+            else:
+                fail_with_msg(f"Invalid connection value: {connection_value}")
+
+            if "'" in wire_name or wire_name.lower() == "z":
+                wire = wire_name
+            else:
+                wire = find_obj_in_list(
+                    issuer.wires, wire_name
+                ) or find_obj_in_list(issuer.ports, wire_name)
+                if not wire:
+                    debug(f"Creating implicit wire '{port.name}' in '{issuer.name}'.", 1)
+                    # Add wire to issuer
+                    wire_signals = remove_signal_direction_suffixes(port.signals)
+                    issuer.create_wire(name=wire_name, signals=wire_signals, descr=port.descr)
+                    # Add wire to attributes_dict as well
+                    issuer.attributes_dict["wires"].append(
+                        {
+                            "name": wire_name,
+                            "signals": wire_signals,
+                            "descr": port.descr,
+                        }
+                    )
+                    wire = issuer.wires[-1]
+            # TODO: review this, probably keep in instance
+            port.connect_external(wire, bit_slices=bit_slices)
+        for port in self.ports:
+            if not port.e_connect and port.interface:
+                if (
+                    port.interface.type in mem_if_names
+                    and issuer
+                    and not self.is_tester
+                ):
+                    # print(f"DEBUG: Creating port '{port.name}' in '{issuer.name}' and connecting it to port of subblock '{self.name}'.", file=sys.stderr)
+                    self.__connect_memory(port, issuer)
+                elif (
+                    port.interface.type == "iob_clk"
+                    and issuer
+                    and not self.is_tester
+                ):
+                    self.__connect_clk_interface(port, issuer)
+
+        # iob_csrs specific code
+        if self.original_name == "iob_csrs" and issuer:
+            self.__connect_cbus_port(issuer)
+
+    def __connect_memory(self, port, issuer):
+        """Create memory port in issuer and connect it to self"""
+        if not issuer.generate_hw or not self.instantiate:
+            return
+        _name = f"{port.name}"
+        _signals = {k: v for k, v in port.interface.__dict__.items() if k != "widths"}
+        _signals.update(port.interface.widths)
+        if _signals["prefix"] == "":
+            _signals.update({"prefix": f"{_name}_"})
+        issuer.create_port(name=_name, signals=_signals, descr=port.descr)
+        # Add port also to attributes_dict
+        issuer.attributes_dict["ports"].append(
+            {
+                "name": _name,
+                "signals": _signals,
+                "descr": port.descr,
+            }
+        )
+        _port = find_obj_in_list(issuer.ports + issuer.wires, _name)
+        port.connect_external(_port, bit_slices=[])
+
+    def __connect_clk_interface(self, port, issuer):
+        """Create, if needed, a clock interface port in issuer and connect it to self"""
+        if not issuer.generate_hw or not self.instantiate:
+            return
+        _name = f"{port.name}"
+        _signals = {k: v for k, v in port.interface.__dict__.items() if k != "widths"}
+        _signals.update(port.interface.widths)
+        for p in issuer.ports:
+            if p.interface:
+                if (
+                    p.interface.type == port.interface.type
+                    and p.interface.prefix == port.interface.prefix
+                ):
+                    if p.interface.params != port.interface.params:
+                        p.interface.params = "_".join(
+                            filter(
+                                lambda x: x != "None",
+                                [p.interface.params, port.interface.params],
+                            )
+                        )
+                        p.signals = []
+                        p.__post_init__()
+                    port.connect_external(p, bit_slices=[])
+                    return
+        issuer.create_port(name=_name, signals=_signals, descr=port.descr)
+        _port = find_obj_in_list(issuer.ports, _name)
+        port.connect_external(_port, bit_slices=[])
+
+
+    def __connect_cbus_port(self, issuer):
+        """Automatically adds "<prefix>_cbus_s" port to issuers of iob_csrs (are usually iob_system peripherals).
+        The '<prefix>' is replaced by instance name of iob_csrs subblock.
+        Also, connects the newly created issuer port to the iob_csrs `control_if_s` port.
+        :param issuer: issuer core object
+        """
+        assert (
+            self.original_name == "iob_csrs"
+        ), "Internal error: cbus can only be created for issuer of 'iob_csrs' module."
+        # Find CSR control port in iob_csrs, and copy its properites to a newly generated "<prefix>_cbus_s" port of issuer
+        csrs_port = find_obj_in_list(self.ports, "control_if_s")
+
+        issuer.create_port(
+            name=f"{self.instance_name}_cbus_s",
+            signals={
+                "type": csrs_port.interface.type,
+                "prefix": self.instance_name + "_",
+                **csrs_port.interface.widths,
+            },
+            descr="Control and Status Registers interface (auto-generated)",
+        )
+        # Connect newly created port to self
+        csrs_port.connect_external(issuer.ports[-1], bit_slices=[])
+
+        # Add port to issuer's attributes_dict
+        issuer.attributes_dict["ports"].append(
+            {
+                "name": f"{self.instance_name}_cbus_s",
+                "signals": {
+                    "type": csrs_port.interface.type,
+                    "prefix": self.instance_name + "_",
+                    **csrs_port.interface.widths,
+                },
+                "descr": "Control and Status Registers interface (auto-generated)",
+            }
+        )

--- a/py2hwsw/scripts/iob_instance.py
+++ b/py2hwsw/scripts/iob_instance.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import copy
 from typing import Dict
 
 from iob_base import iob_base
@@ -63,3 +64,35 @@ class iob_instance(iob_base):
             bool,
             descr="Select if should intantiate the module inside another Verilog module.",
         )
+
+    def __deepcopy__(self, memo):
+        """Create a deep copy of this instance:
+        - iob_instance attributes are copied by value
+        - super() attributes are copied by reference
+        """
+        # Create a new instance without calling __init__ to avoid side effects
+        cls = self.__class__
+        new_obj = cls.__new__(cls)
+
+        # Add to memo to handle circular references
+        memo[id(self)] = new_obj
+
+        # Copy class iob_instance attributes by value (deep copy)
+        instance_attributes = {
+            "instance_name",
+            "instance_description",
+            "parameters",
+            "if_defined",
+            "if_not_defined",
+            "instantiate",
+        }
+
+        for attr_name, attr_value in self.__dict__.items():
+            if attr_name in instance_attributes:
+                # Deep copy iob_instance attributes
+                setattr(new_obj, attr_name, copy.deepcopy(attr_value, memo))
+            else:
+                # Copy inherited attributes by reference (shallow copy)
+                setattr(new_obj, attr_name, attr_value)
+
+        return new_obj

--- a/py2hwsw/scripts/iob_module.py
+++ b/py2hwsw/scripts/iob_module.py
@@ -160,8 +160,8 @@ class iob_module(iob_base):
 
     def create_subblock(self, *args, **kwargs):
         if self.is_superblock:
-            # Remove instantiator subblock to ensure that it is not setup again
-            if self.handle_instantiator_subblock(*args, **kwargs):
+            # Remove issuer subblock to ensure that it is not setup again
+            if self.handle_issuer_subblock(*args, **kwargs):
                 return
         create_block(self, *args, **kwargs)
 
@@ -176,39 +176,39 @@ class iob_module(iob_base):
         if not __class__.global_top_module:
             __class__.global_top_module = self
 
-    def handle_instantiator_subblock(self, *args, **kwargs):
-        """If given kwargs describes the instantiator subblock, return True. Otherwise return False.
-        Also append instantiator object found to the core's 'subblocks' list.
+    def handle_issuer_subblock(self, *args, **kwargs):
+        """If given kwargs describes the issuer subblock, return True. Otherwise return False.
+        Also append issuer object found to the core's 'subblocks' list.
         """
-        instantiator = self.instantiator
-        if kwargs.get("core_name") == instantiator.original_name:
-            self.update_instantiator_obj(instantiator, kwargs)
+        issuer = self.issuer
+        if kwargs.get("core_name") == issuer.original_name:
+            self.update_issuer_obj(issuer, kwargs)
             return True
         else:
             return False
 
-    def update_instantiator_obj(self, instantiator_obj, instance_dict):
-        """Update given instantiator object with values for verilog parameters and external port connections.
-        Also, add instantiator object to the 'subblocks' list of this superblock.
-        :param instantiator_obj: Instantiator object
+    def update_issuer_obj(self, issuer_obj, instance_dict):
+        """Update given issuer object with values for verilog parameters and external port connections.
+        Also, add issuer object to the 'subblocks' list of this superblock.
+        :param issuer_obj: issuer object
         :param instance_dict: Dictionary describing verilog instance. Includes port connections and verilog parameter values.
         """
-        new_instance = copy.deepcopy(instantiator_obj)
-        new_instance.instantiate = True
+        new_issuer_instance = copy.deepcopy(issuer_obj)
+        new_issuer_instance.instantiate = True
         # Set instance name
         if "instance_name" in instance_dict:
-            new_instance.instance_name = instance_dict["instance_name"]
+            new_issuer_instance.instance_name = instance_dict["instance_name"]
         # Set instance description
         if "instance_description" in instance_dict:
-            new_instance.instance_description = instance_dict[
+            new_issuer_instance.instance_description = instance_dict[
                 "instance_description"
             ]
         # Set values to pass via verilog parameters
-        new_instance.parameters = instance_dict.get("parameters", {})
-        # Connect ports of instantiator to external wires (wires of this superblock)
-        new_instance.connect_instance_ports(instance_dict.get("connect", {}), self)
-        # Create a instantiator subblock, and add it to the 'subblocks' list of current superblock
-        self.subblocks.append(new_instance)
+        new_issuer_instance.parameters = instance_dict.get("parameters", {})
+        # Connect ports of issuer to external wires (wires of this superblock)
+        new_issuer_instance.connect_instance_ports(instance_dict.get("connect", {}), self)
+        # Create a issuer subblock, and add it to the 'subblocks' list of current superblock
+        self.subblocks.append(new_issuer_instance)
 
 
 def get_list_attr_handler(func):

--- a/py2hwsw/scripts/iob_module.py
+++ b/py2hwsw/scripts/iob_module.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import copy
+
 from iob_base import iob_base, process_elements_from_list, fail_with_msg
 from iob_conf import create_conf_group
 from iob_port import create_port
@@ -191,21 +193,22 @@ class iob_module(iob_base):
         :param instantiator_obj: Instantiator object
         :param instance_dict: Dictionary describing verilog instance. Includes port connections and verilog parameter values.
         """
-        instantiator_obj.instantiate = True
+        new_instance = copy.deepcopy(instantiator_obj)
+        new_instance.instantiate = True
         # Set instance name
         if "instance_name" in instance_dict:
-            instantiator_obj.instance_name = instance_dict["instance_name"]
+            new_instance.instance_name = instance_dict["instance_name"]
         # Set instance description
         if "instance_description" in instance_dict:
-            instantiator_obj.instance_description = instance_dict[
+            new_instance.instance_description = instance_dict[
                 "instance_description"
             ]
         # Set values to pass via verilog parameters
-        instantiator_obj.parameters = instance_dict.get("parameters", {})
+        new_instance.parameters = instance_dict.get("parameters", {})
         # Connect ports of instantiator to external wires (wires of this superblock)
-        instantiator_obj.connect_instance_ports(instance_dict.get("connect", {}), self)
+        new_instance.connect_instance_ports(instance_dict.get("connect", {}), self)
         # Create a instantiator subblock, and add it to the 'subblocks' list of current superblock
-        self.subblocks.append(instantiator_obj)
+        self.subblocks.append(new_instance)
 
 
 def get_list_attr_handler(func):

--- a/py2hwsw/scripts/iob_port.py
+++ b/py2hwsw/scripts/iob_port.py
@@ -5,17 +5,14 @@
 from dataclasses import dataclass, field
 
 import if_gen
-import iob_colors
 from iob_wire import iob_wire, replace_duplicate_signals_by_references
 from iob_base import (
     convert_dict2obj_list,
     fail_with_msg,
     str_to_kwargs,
     assert_attributes,
-    find_obj_in_list,
-    validate_verilog_const,
 )
-from iob_signal import iob_signal, get_real_signal
+from iob_signal import iob_signal
 
 
 @dataclass
@@ -103,98 +100,6 @@ class iob_port(iob_wire):
                 f"Port '{self.name}' has 'inout' direction but no outputs defined",
                 ValueError,
             )
-
-    def connect_external(self, wire, bit_slices={}):
-        """Connects the port to an external wire
-        Verifies that the wire is compatible with the port
-        :param iob_wire wire: external wire
-        :param list bit_slices: bit slices of signals in wire
-        """
-        # wire must be iob_wire or str
-        if isinstance(wire, str):
-            if len(self.signals) != 1:
-                fail_with_msg(
-                    f"{iob_colors.FAIL}Port '{self.name}' has more than one signal but is connected to one constant value '{self.e_connect}'!{iob_colors.ENDC}",
-                    ValueError,
-                )
-            else:
-                validate_verilog_const(value=wire, direction=self.signals[0].direction)
-        elif isinstance(wire, iob_wire):
-            if self.interface and wire.interface:
-                if self.interface.type == wire.interface.type:
-                    for signal in self.signals:
-                        search_name = signal.name.replace(
-                            self.interface.prefix, wire.interface.prefix, 1
-                        )
-                        if self.name[-2] != wire.name[-2]:
-                            swap_suffix = {
-                                "_i": "_o",
-                                "_o": "_i",
-                            }
-                            if wire.name[-2:] in ["_s", "_m"]:
-                                search_name += (
-                                    search_name[:-2] + swap_suffix[search_name[-2:]]
-                                )
-                            else:
-                                search_name = search_name[:-2]
-                        e_signal = find_obj_in_list(
-                            wire.signals, search_name, get_real_signal
-                        )
-                        if not e_signal:
-                            if not any(
-                                [
-                                    f"{signal.name}:" in bit_slice
-                                    for bit_slice in bit_slices
-                                ]
-                            ):
-                                newlinechar = "\n"
-                                fail_with_msg(
-                                    f"""Port '{self.name}' signal '{signal.name}' not connected to external wire '{wire.name}'!
-Port '{self.name}' has the following signals:                                                                   
-
-{newlinechar.join("- " + signal.name for signal in self.signals)}                                               
-External connection '{wire.name}' has the following signals:                                                    
-{newlinechar.join("- " + signal.name for signal in wire.signals)}                                               
-""",
-                                    ValueError,
-                                )
-                elif len(self.signals) != len(wire.signals):
-                    newlinechar = "\n"
-                    fail_with_msg(
-                        f"""Port '{self.name}' has different number of signals compared to external connection '{wire.name}'!
-Port '{self.name}' has the following signals:
-{newlinechar.join("- " + signal.name for signal in self.signals)}
-
-External connection '{wire.name}' has the following signals:
-{newlinechar.join("- " + signal.name for signal in wire.signals)}
-""",
-                        ValueError,
-                    )
-            elif len(self.signals) != len(wire.signals):
-                newlinechar = "\n"
-                fail_with_msg(
-                    f"""Port '{self.name}' has different number of signals compared to external connection '{wire.name}'!
-Port '{self.name}' has the following signals:
-{newlinechar.join("- " + get_real_signal(signal).name for signal in self.signals)}
-
-External connection '{wire.name}' has the following signals:
-{newlinechar.join("- " + get_real_signal(signal).name for signal in wire.signals)}
-""",
-                    ValueError,
-                )
-            else:
-                for p, w in zip(self.signals, wire.signals):
-                    w = get_real_signal(w)
-                    if "'" in w.name or w.name.lower() == "z":
-                        validate_verilog_const(value=w.name, direction=p.direction)
-        else:
-            fail_with_msg(
-                f"Invalid wire type! {wire}. Must be iob_wire or str",
-                TypeError,
-            )
-
-        self.e_connect = wire
-        self.e_connect_bit_slices = bit_slices
 
 
 attrs = [

--- a/py2hwsw/scripts/iob_port.py
+++ b/py2hwsw/scripts/iob_port.py
@@ -19,11 +19,6 @@ from iob_signal import iob_signal
 class iob_port(iob_wire):
     """Describes an IO port."""
 
-    # External wire that connects this port
-    e_connect: iob_wire | None = None
-    # Dictionary of bit slices for external connections. Name: signal name; Value: bit slice
-    e_connect_bit_slices: list = field(default_factory=list)
-    # If enabled, port will only appear in documentation. Not in the verilog code.
     doc_only: bool = False
     # If enabled, the documentation table for this port will be terminated by a TeX '\clearpage' command.
     doc_clearpage: bool = False

--- a/py2hwsw/scripts/iob_portmap.py
+++ b/py2hwsw/scripts/iob_portmap.py
@@ -119,9 +119,8 @@ External connection '{wire.name}' has the following signals:
         self.e_connect_bit_slices = bit_slices
 
 
-def get_portmap_port(portmap: iob_portmap):
-    """Given a iob_portmap reference, return port.
-    This function is used as process_func for find_obj_in_list().
+def get_portmap_port(portmap):
+    """Given a portmap reference, return the associated port
     """
     port = None
     if isinstance(portmap, iob_portmap):

--- a/py2hwsw/scripts/iob_portmap.py
+++ b/py2hwsw/scripts/iob_portmap.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2025 IObundle
+#
+# SPDX-License-Identifier: MIT
+
+from dataclasses import dataclass, field
+
+from iob_base import (
+    fail_with_msg,
+    find_obj_in_list,
+    validate_verilog_const,
+)
+import iob_colors
+from iob_port import iob_port
+from iob_signal import get_real_signal
+from iob_wire import iob_wire
+
+
+@dataclass
+class iob_portmap(iob_port):
+    """Describes an IO portmap connection."""
+
+    # External wire that connects this port
+    e_connect: iob_wire | None = None
+    # Dictionary of bit slices for external connections. Name: signal name; Value: bit slice
+    e_connect_bit_slices: list = field(default_factory=list)
+
+    # TODO: create constructor from port?
+    def __init__(self, port: iob_port):
+        # Iterate over the port attributes
+        for key, value in port.__dict__.items():
+            setattr(self, key, value)
+
+    def connect_external(self, wire, bit_slices={}):
+        """Connects the port to an external wire
+        Verifies that the wire is compatible with the port
+        :param iob_wire wire: external wire
+        :param list bit_slices: bit slices of signals in wire
+        """
+        # wire must be iob_wire or str
+        if isinstance(wire, str):
+            if len(self.signals) != 1:
+                fail_with_msg(
+                    f"{iob_colors.FAIL}Port '{self.name}' has more than one signal but is connected to one constant value '{self.e_connect}'!{iob_colors.ENDC}",
+                    ValueError,
+                )
+            else:
+                validate_verilog_const(value=wire, direction=self.signals[0].direction)
+        elif isinstance(wire, iob_wire):
+            if self.interface and wire.interface:
+                if self.interface.type == wire.interface.type:
+                    for signal in self.signals:
+                        search_name = signal.name.replace(
+                            self.interface.prefix, wire.interface.prefix, 1
+                        )
+                        if self.name[-2] != wire.name[-2]:
+                            swap_suffix = {
+                                "_i": "_o",
+                                "_o": "_i",
+                            }
+                            if wire.name[-2:] in ["_s", "_m"]:
+                                search_name += (
+                                    search_name[:-2] + swap_suffix[search_name[-2:]]
+                                )
+                            else:
+                                search_name = search_name[:-2]
+                        e_signal = find_obj_in_list(
+                            wire.signals, search_name, get_real_signal
+                        )
+                        if not e_signal:
+                            if not any(
+                                [
+                                    f"{signal.name}:" in bit_slice
+                                    for bit_slice in bit_slices
+                                ]
+                            ):
+                                newlinechar = "\n"
+                                fail_with_msg(
+                                    f"""Port '{self.name}' signal '{signal.name}' not connected to external wire '{wire.name}'!
+Port '{self.name}' has the following signals:                                                                   
+
+{newlinechar.join("- " + signal.name for signal in self.signals)}                                               
+External connection '{wire.name}' has the following signals:                                                    
+{newlinechar.join("- " + signal.name for signal in wire.signals)}                                               
+""",
+                                    ValueError,
+                                )
+                elif len(self.signals) != len(wire.signals):
+                    newlinechar = "\n"
+                    fail_with_msg(
+                        f"""Port '{self.name}' has different number of signals compared to external connection '{wire.name}'!
+Port '{self.name}' has the following signals:
+{newlinechar.join("- " + signal.name for signal in self.signals)}
+
+External connection '{wire.name}' has the following signals:
+{newlinechar.join("- " + signal.name for signal in wire.signals)}
+""",
+                        ValueError,
+                    )
+            elif len(self.signals) != len(wire.signals):
+                newlinechar = "\n"
+                fail_with_msg(
+                    f"""Port '{self.name}' has different number of signals compared to external connection '{wire.name}'!
+Port '{self.name}' has the following signals:
+{newlinechar.join("- " + get_real_signal(signal).name for signal in self.signals)}
+
+External connection '{wire.name}' has the following signals:
+{newlinechar.join("- " + get_real_signal(signal).name for signal in wire.signals)}
+""",
+                    ValueError,
+                )
+            else:
+                for p, w in zip(self.signals, wire.signals):
+                    w = get_real_signal(w)
+                    if "'" in w.name or w.name.lower() == "z":
+                        validate_verilog_const(value=w.name, direction=p.direction)
+        else:
+            fail_with_msg(
+                f"Invalid wire type! {wire}. Must be iob_wire or str",
+                TypeError,
+            )
+
+        self.e_connect = wire
+        self.e_connect_bit_slices = bit_slices

--- a/py2hwsw/scripts/manage_headers.py
+++ b/py2hwsw/scripts/manage_headers.py
@@ -286,10 +286,9 @@ def generate_headers(
     for file in files:
         write_independent_lic_file(file, header)
 
-    # # Download license using `reuse` tool
-    # breakpoint()
-    # if not os.path.isfile(os.path.join(root, f"LICENSES/{license_name}.txt")):
-    #     os.system(f"reuse --root {root} download {license_name}")
+    # Download license using `reuse` tool
+    if not os.path.isfile(os.path.join(root, f"LICENSES/{license_name}.txt")):
+        os.system(f"reuse --root {root} download {license_name}")
 
 
 def write_independent_lic_file(file, header):

--- a/py2hwsw/scripts/manage_headers.py
+++ b/py2hwsw/scripts/manage_headers.py
@@ -286,9 +286,10 @@ def generate_headers(
     for file in files:
         write_independent_lic_file(file, header)
 
-    # Download license using `reuse` tool
-    if not os.path.isfile(os.path.join(root, f"LICENSES/{license_name}.txt")):
-        os.system(f"reuse --root {root} download {license_name}")
+    # # Download license using `reuse` tool
+    # breakpoint()
+    # if not os.path.isfile(os.path.join(root, f"LICENSES/{license_name}.txt")):
+    #     os.system(f"reuse --root {root} download {license_name}")
 
 
 def write_independent_lic_file(file, header):

--- a/py2hwsw/scripts/py2hwsw.py
+++ b/py2hwsw/scripts/py2hwsw.py
@@ -203,7 +203,8 @@ if __name__ == "__main__":
             py_params[k] = v
 
     if args.target == "setup":
-        iob_core.get_core_obj(args.core_name, **py_params)
+        instance = iob_core.get_core_obj(args.core_name, **py_params)
+        instance.generate_build_dir()
     elif args.target == "clean":
         iob_core.clean_build_dir(args.core_name)
     elif args.target == "print_build_dir":


### PR DESCRIPTION
split py2hwsw core setup into 2 stages:
1. `iob_core` object initialization
2. `BUILD_DIR` generation

- rename `instantiator` to `issuer`
- improve `iob_instance`  class
- create new `iob_portmap` to associate `port` with correspondent external connection for each instance

this refactor is one of the steps required to implement changes in #287 