### PR TITLE
wip(notation): Implement short notation for py2 classes

### DIFF
--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -202,6 +202,31 @@ if __name__ == "__main__":
     print(comb_obj.get_code())
     print("======\n\n")
 
+    fsm_obj = py2hwsw.create_fsm_from_text(
+        """
+            -t fsm
+            -d 'a_o = 10;'
+            -s
+            '
+                A: a_o = 0;
+                B: a_o = 1;
+                a_o = 2;
+                if(a_o == 0)
+                begin
+                    pcnt_nxt = A;
+                end
+                else
+                begin
+                    pcnt_nxt = B;
+                end
+            '
+        """
+    )
+    print(">>> fsm_obj: ", fsm_obj.get_kind())
+    print(">>> default assignments of fsm_obj:\n", fsm_obj.get_default_assignments())
+    print(">>> state descriptions of fsm_obj:\n", fsm_obj.get_state_descriptions())
+    print("======\n")
+
     core_obj = py2hwsw.create_core_from_dict(core_dictionary)
     print(">>> Generate_hw of core_obj: ", core_obj.get_generate_hw())
     print(">>> Ports of core_obj: ", [i.get_name() for i in core_obj.get_ports()])

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -227,6 +227,11 @@ if __name__ == "__main__":
     print(">>> state descriptions of fsm_obj:\n", fsm_obj.get_state_descriptions())
     print("======\n")
 
+    license_obj = py2hwsw.create_license_from_text("""MIT -y 2025 -a 'IObundle, Lda'""")
+    print(f">>> License name: {license_obj.get_name()}")
+    print(f"\tyear: {license_obj.get_year()}\n\tauthor: {license_obj.get_author()}")
+    print("======\n")
+
     core_obj = py2hwsw.create_core_from_dict(core_dictionary)
     print(">>> Generate_hw of core_obj: ", core_obj.get_generate_hw())
     print(">>> Ports of core_obj: ", [i.get_name() for i in core_obj.get_ports()])

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -180,9 +180,7 @@ if __name__ == "__main__":
     print(">>> Verilog of snippet_obj: ", snippet_obj.get_verilog_code())
 
     print("\n\nSnippet from text:")
-    snippet_obj = py2hwsw.create_snippet_from_text(
-        {"verilog_code": "   assign y_o = a_i & b_i;"}
-    )
+    snippet_obj = py2hwsw.create_snippet_from_text("   assign y_o = a_i & b_i;")
     print(">>> Verilog of snippet_obj: ", snippet_obj.get_verilog_code())
 
     comb_obj = py2hwsw.create_comb_from_text(

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -179,6 +179,12 @@ if __name__ == "__main__":
     )
     print(">>> Verilog of snippet_obj: ", snippet_obj.get_verilog_code())
 
+    print("\n\nSnippet from text:")
+    snippet_obj = py2hwsw.create_snippet_from_text(
+        {"verilog_code": "   assign y_o = a_i & b_i;"}
+    )
+    print(">>> Verilog of snippet_obj: ", snippet_obj.get_verilog_code())
+
     core_obj = py2hwsw.create_core_from_dict(core_dictionary)
     print(">>> Generate_hw of core_obj: ", core_obj.get_generate_hw())
     print(">>> Ports of core_obj: ", [i.get_name() for i in core_obj.get_ports()])

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -185,6 +185,23 @@ if __name__ == "__main__":
     )
     print(">>> Verilog of snippet_obj: ", snippet_obj.get_verilog_code())
 
+    comb_obj = py2hwsw.create_comb_from_text(
+        """
+            -c
+            "
+                // Register data
+                data_nxt = data;
+            "
+            -clk_if c_a_r
+            -clk_p data_
+        """
+    )
+    print(">>> comb_obj: clk_if: ", comb_obj.get_clk_if(), end=" ")
+    print("|\t clk_prefix: ", comb_obj.get_clk_prefix())
+    print("code:")
+    print(comb_obj.get_code())
+    print("======\n\n")
+
     core_obj = py2hwsw.create_core_from_dict(core_dictionary)
     print(">>> Generate_hw of core_obj: ", core_obj.get_generate_hw())
     print(">>> Ports of core_obj: ", [i.get_name() for i in core_obj.get_ports()])

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -165,6 +165,15 @@ if __name__ == "__main__":
     print(">>> Name of port_obj: ", port_obj.get_name())
     print(">>> Name of port signal: ", port_obj.get_signals()[0].get_name())
 
+    port_obj = py2hwsw.create_port_from_text(
+        "control -d 'control bus' -s start_i:1 -s done_o:1 -s cmd_i:CMD_W -doc"
+    )
+    print(">>> Name of port_obj: ", port_obj.get_name())
+    print(">>> port_obj doc_only: ", port_obj.get_doc_only())
+    print(">>> port_obj doc_clearpage: ", port_obj.get_doc_clearpage())
+    for s in port_obj.get_signals():
+        print("\t>>> Signal name: ", s.get_name(), "width:", s.get_width())
+
     snippet_obj = py2hwsw.create_snippet_from_dict(
         {"verilog_code": "   assign y_o = a_i & b_i;"}
     )

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
         -doc
         -doc_clearpage
         --confs
-            "
+            {{
             DATA_W -t P -v 32 -m NA -M NA
             -d 'Data bus width'
 
@@ -108,7 +108,7 @@ if __name__ == "__main__":
 
             COUNT_W -t D -v $clog2(END_COUNT) -m NA -M NA
             -d 'Count width'
-            "
+            }}
         """
     )
     print(conf_groups_obj.get_name())
@@ -188,10 +188,10 @@ if __name__ == "__main__":
     comb_obj = py2hwsw.create_comb_from_text(
         """
             -c
-            "
+            {{
                 // Register data
                 data_nxt = data;
-            "
+            }}
             -clk_if c_a_r
             -clk_p data_
         """
@@ -207,7 +207,7 @@ if __name__ == "__main__":
             -t fsm
             -d 'a_o = 10;'
             -s
-            '
+            {{
                 A: a_o = 0;
                 B: a_o = 1;
                 a_o = 2;
@@ -219,7 +219,7 @@ if __name__ == "__main__":
                 begin
                     pcnt_nxt = B;
                 end
-            '
+             }}
         """
     )
     print(">>> fsm_obj: ", fsm_obj.get_kind())

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -143,6 +143,16 @@ if __name__ == "__main__":
         print("\tsignal: ", signal.get_name(), "width:", signal.get_width())
     print("descr: ", wire_obj.get_descr())
 
+    # iface_obj = py2hwsw.create_interface_from_text(
+    #     "axi -d manager -p cpu_ -m 1 -f ctrl_cpu_ -pm controller_"
+    # )
+    # iface_obj = py2hwsw.create_interface_from_text(
+    #     "rom_sp -d subordinate -p boot_ -w ADDR_W:8 -w DATA_W:32"
+    # )
+    # iface_obj = py2hwsw.create_interface_from_text(
+    #     "axis -p output_ -P 'has_tlast'"
+    # )
+
     port_obj = py2hwsw.create_port_from_dict(
         {
             "name": "a_i",

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -241,6 +241,20 @@ if __name__ == "__main__":
     )
     print("======\n")
 
+    py_param_group_obj = py2hwsw.create_python_parameter_group_from_text(
+        """
+                param_group -d 'Group of parameters' -doc_clearpage
+                -P "param1 -v 42 -d 'Parameter 1 description'"
+                -P "OUTPUT_W -v DATA_W -d 'Data width'"
+         """
+    )
+    print(f">>> Python parameter group name: {py_param_group_obj.get_name()}")
+    print(f"\tdescr: {py_param_group_obj.get_descr()}")
+    for param in py_param_group_obj.get_python_parameters():
+        print(f"\t>>> Parameter name: {param.get_name()}")
+        print(f"\t\tvalue: {param.get_val()}\n\t\tdescr: {param.get_descr()}")
+    print("======\n")
+
     core_obj = py2hwsw.create_core_from_dict(core_dictionary)
     print(">>> Generate_hw of core_obj: ", core_obj.get_generate_hw())
     print(">>> Ports of core_obj: ", [i.get_name() for i in core_obj.get_ports()])

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -232,6 +232,15 @@ if __name__ == "__main__":
     print(f"\tyear: {license_obj.get_year()}\n\tauthor: {license_obj.get_author()}")
     print("======\n")
 
+    python_parameter_obj = py2hwsw.create_python_parameter_from_text(
+        "my_param -v 42 -d 'My parameter description'"
+    )
+    print(f">>> python_parameter name: {python_parameter_obj.get_name()}")
+    print(
+        f"\tvalue: {python_parameter_obj.get_val()}\n\tdescr: {python_parameter_obj.get_descr()}"
+    )
+    print("======\n")
+
     core_obj = py2hwsw.create_core_from_dict(core_dictionary)
     print(">>> Generate_hw of core_obj: ", core_obj.get_generate_hw())
     print(">>> Ports of core_obj: ", [i.get_name() for i in core_obj.get_ports()])

--- a/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
+++ b/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
@@ -19,6 +19,9 @@ from memories import find_and_update_regfile_csrs
 from memories import find_and_update_ram_csrs
 from special_csrs import find_and_update_autoclear_csrs
 
+from iob_base import parse_short_notation_text
+from csr_classes import iob_csr_group_text2dict
+
 # Static (shared) dictionary to store reg tables of generated csrs
 # May be read by other python modules
 static_reg_tables = {}
@@ -445,3 +448,41 @@ def _reset_autoaddrs(autoaddr, csrs):
         for csr_group in csrs:
             for r in csr_group.regs:
                 r.addr = -1
+
+
+def csrs_text2dict(csrs_text):
+    """Convert iob_csrs short notation text to dictionary
+    Attributes:
+        csrs_text (str): short notation text. Specified with the following format:
+            [--csr_if CSR_IF] [--rw_overlap] [--autoaddr] [--doc_conf DOC_CONF]
+            [--csr-group csr_group]+
+            See `iob_csr_group_text2dict()` for `csr_group` format details.
+            Example:
+                --csr_if iob --rw_overlap --no-autoaddr --doc_conf full
+                --csr-group "
+                    ctrl -d 'Control registers' -doc -doc_clearpage
+                    -r \\"softreset:1 -m W -d 'Soft reset' --rst_val 0 --addr 0 --log2n_items 0\\"
+                    -r \\"start:1 -m W -d 'Start operation' --rst_val 0 --addr 1 --log2n_items 1\\"
+                    -r \\"done:1 -m R -d 'Operation Complete' --rst_val 1 --addr 2 --log2n_items 1 --doc_conf full\\"
+                "
+                --csr-group "
+                    data -d 'Data registers' -doc -doc_clearpage
+                    -r \\"d_in:32 -m W -d 'Data input' --rst_val 0 --addr 4 --log2n_items 0\\"
+                    -r \\"d_out:8 -m R -d 'Data output' --rst_val 255 --addr 8 --log2n_items 0\\"
+                "
+
+    Returns:
+        list: with csrs attributes / python parameters list
+    """
+    csrs_flags = [
+        ["--csr_if", {"dest": "csr_if", "default": "iob"}],
+        ["--rw_overlap", {"dest": "rw_overlap", "action": "store_true"}],
+        ["--no-autoaddr", {"dest": "autoaddr", "action": "store_false"}],
+        ["--doc_conf", {"dest": "doc_conf"}],
+        ["--csr-group", {"dest": "csr-group", "action": "append"}],
+    ]
+    csrs_dict: dict = parse_short_notation_text(csrs_text, csrs_flags)
+    csrs_list: list = []
+    for c_group in csrs_dict.get("csr-group", []):
+        csrs_list.append(iob_csr_group_text2dict(c_group))
+    return csrs_list

--- a/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
+++ b/py2hwsw/lib/hardware/iob_csrs/iob_csrs.py
@@ -475,7 +475,7 @@ def csrs_text2dict(csrs_text):
         list: with csrs attributes / python parameters list
     """
     csrs_flags = [
-        ["--csr_if", {"dest": "csr_if", "default": "iob"}],
+        ["--csr_if", {"dest": "csr_if"}],
         ["--rw_overlap", {"dest": "rw_overlap", "action": "store_true"}],
         ["--no-autoaddr", {"dest": "autoaddr", "action": "store_false"}],
         ["--doc_conf", {"dest": "doc_conf"}],

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_classes.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_classes.py
@@ -4,6 +4,8 @@
 
 from dataclasses import dataclass, field
 
+from iob_base import parse_short_notation_text
+
 FAIL = "\033[91mError: "  # Red
 ENDC = "\033[0m"  # White
 
@@ -240,3 +242,74 @@ def create_csr_group(*args, **kwargs):
     csr_obj_list = convert_dict2obj_list(regs, iob_csr)
     csr_group = iob_csr_group(regs=csr_obj_list, **group_kwargs)
     return csr_group
+
+
+def iob_csr_text2dict(csr_text: str):
+    """Convert iob_csr short notation text to dictionary
+    Attributes:
+        csr_text (str): short notation text
+            Example:
+                "softreset:1 -m W -d 'Soft reset' --rst_val 0 --addr 0 --log2n_items 0
+
+    Returns:
+        dict: dictionary with iob_csr attributes
+    """
+    csr_flags = [
+        "name&width",
+        ["-k", {"dest": "kind", "choices": ["REG", "NOAUTO"], "default": "REG"}],
+        ["-m", {"dest": "mode", "choices": ["R", "W", "RW"], "default": ""}],
+        ["--rst_val", {"dest": "rst_val", "default": 0}],
+        ["--addr", {"dest": "addr", "default": -1}],
+        ["--log2n_items", {"dest": "log2n_items", "default": 0}],
+        ["-d", {"dest": "descr"}],
+        ["--int_use", {"dest": "internal_use", "default": False}],
+        ["--fields", {"dest": "fields"}],
+        ["--assym", {"dest": "assym", "default": 1}],
+        ["--opt_comment", {"dest": "optional_comment", "default": ""}],
+    ]
+
+    csr_dict = parse_short_notation_text(csr_text, csr_flags)
+    # process 'name&width', with format '[name]:[width]'
+    name_and_width = csr_dict.pop('name&width', "")
+    try:
+        csr_dict['name'], csr_dict['width'] = name_and_width.split(':', 1)
+    except ValueError:
+        csr_dict['name'] = name_and_width
+        csr_dict['width'] = 1  # default width 1 if not specified
+    return csr_dict
+
+
+def iob_csr_group_text2dict(csr_group_text: str):
+    """Convert iob_csr_group short notation text to dictionary
+    Attributes:
+        csr_group_text (str): short notation text
+            [csr group name] [-d descr] [-r reg]+ [-doc] [-doc_clearpage]
+            Example:
+                ctrl_regs
+                -d 'control registers'
+                -doc
+                -doc_clearpage
+                -r "softreset:1 -m W -d 'Soft reset' --rst_val 0 --addr 0 --log2n_items 0"
+                -r "start:1 -m W -d 'Start operation' --rst_val 0 --addr 1 --log2n_items 1"
+                -r "done:1 -m R -d 'Operation Complete' --rst_val 1 --addr 2 --log2n_items 1"
+
+    Returns:
+        dict: dictionary with iob_csr attributes
+    """
+    csr_group_flags = [
+        "name",
+        ["-d", {"dest": "descr"}],
+        ["-doc", {"dest": "doc_only", "action": "store_true"}],
+        ["-doc_clearpage", {"dest": "doc_clearpage", "action": "store_true"}],
+        ["-r", {"dest": "regs", "action": "append"}],
+    ]
+
+    csr_group_dict = parse_short_notation_text(csr_group_text, csr_group_flags)
+    # process regs
+    csr_group_regs = []
+    for r in csr_group_dict.get('regs', []):
+        # Convert each reg from text to dict
+        csr_group_regs.append(iob_csr_text2dict(r))
+    # update csr_group regs
+    csr_group_dict.update({'regs': csr_group_regs})
+    return csr_group_dict

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_classes.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_classes.py
@@ -259,18 +259,18 @@ def iob_csr_text2dict(csr_text: str):
     """
     csr_flags = [
         "name&width",
-        ["-k", {"dest": "kind", "choices": ["REG", "NOAUTO"], "default": "REG"}],
-        ["-m", {"dest": "mode", "choices": ["R", "W", "RW"], "default": ""}],
-        ["--rst_val", {"dest": "rst_val", "default": 0}],
-        ["--addr", {"dest": "addr", "default": -1}],
-        ["--log2n_items", {"dest": "log2n_items", "default": 0}],
+        ["-k", {"dest": "kind", "choices": ["REG", "NOAUTO"]}],
+        ["-m", {"dest": "mode", "choices": ["R", "W", "RW"]}],
+        ["--rst_val", {"dest": "rst_val"}],
+        ["--addr", {"dest": "addr"}],
+        ["--log2n_items", {"dest": "log2n_items"}],
         ["-d", {"dest": "descr"}],
         ["--doc_conf", {"dest": "doc_conf_list", "action": "append"}],
         ["--no-volatile", {"dest": "volatile", "action": "store_false"}],
         ["--int_use", {"dest": "internal_use", "action": "store_true"}],
         ["--field", {"dest": "fields", "action": "append"}],
-        ["--assym", {"dest": "assym", "default": 1}],
-        ["--opt_comment", {"dest": "optional_comment", "default": ""}],
+        ["--assym", {"dest": "assym"}],
+        ["--opt_comment", {"dest": "optional_comment"}],
     ]
 
     csr_dict = parse_short_notation_text(csr_text, csr_flags)

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_classes.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_classes.py
@@ -247,7 +247,10 @@ def create_csr_group(*args, **kwargs):
 def iob_csr_text2dict(csr_text: str):
     """Convert iob_csr short notation text to dictionary
     Attributes:
-        csr_text (str): short notation text
+        csr_text (str): short notation text. Specified with the following format:
+            name:width [-k KIND] [-m MODE] [--ret_val RST_VAL] [--addr ADDR]
+            [-d descr] [--int_use] [--field FIELD]+ [--doc_conf DOC_CONF]+
+            [--no-volatile] [--assym A] [--opt_comment COMMENT]
             Example:
                 "softreset:1 -m W -d 'Soft reset' --rst_val 0 --addr 0 --log2n_items 0
 
@@ -262,8 +265,10 @@ def iob_csr_text2dict(csr_text: str):
         ["--addr", {"dest": "addr", "default": -1}],
         ["--log2n_items", {"dest": "log2n_items", "default": 0}],
         ["-d", {"dest": "descr"}],
-        ["--int_use", {"dest": "internal_use", "default": False}],
-        ["--fields", {"dest": "fields"}],
+        ["--doc_conf", {"dest": "doc_conf_list", "action": "append"}],
+        ["--no-volatile", {"dest": "volatile", "action": "store_false"}],
+        ["--int_use", {"dest": "internal_use", "action": "store_true"}],
+        ["--field", {"dest": "fields", "action": "append"}],
         ["--assym", {"dest": "assym", "default": 1}],
         ["--opt_comment", {"dest": "optional_comment", "default": ""}],
     ]
@@ -284,6 +289,7 @@ def iob_csr_group_text2dict(csr_group_text: str):
     Attributes:
         csr_group_text (str): short notation text
             [csr group name] [-d descr] [-r reg]+ [-doc] [-doc_clearpage]
+            See `iob_csr_text2dict()` for `csr` format details.
             Example:
                 ctrl_regs
                 -d 'control registers'

--- a/py2hwsw/scripts/fsm_gen.py
+++ b/py2hwsw/scripts/fsm_gen.py
@@ -11,7 +11,7 @@ def generate_fsm(core):
     """Generate verilog code with the fsm of this module.
     returns: Generated verilog code
     """
-    if core.fsm != None:
+    if core.fsm is not None:
         return convert2internal(core.fsm).verilog_code
 
     return ""

--- a/py2hwsw/scripts/interfaces.py
+++ b/py2hwsw/scripts/interfaces.py
@@ -2172,7 +2172,7 @@ def interface_from_dict(interface_dict):
     return create_interface(**interface_dict)
 
 
-def interface_from_text(interface_text):
+def interface_text2dict(interface_text):
     interface_flags = [
         "genre",
         ["-d", {"dest": "if_direction", "choices": ["", "manager", "subordinate"]}],
@@ -2193,4 +2193,8 @@ def interface_from_text(interface_text):
             else:
                 raise ValueError(f"Invalid width specification: {width}")
     interface_dict.update({"widths": width_dict})
-    return create_interface(**interface_dict)
+    return interface_dict
+
+
+def interface_from_text(interface_text):
+    return interface_from_dict(interface_text2dict(interface_text))

--- a/py2hwsw/scripts/interfaces.py
+++ b/py2hwsw/scripts/interfaces.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from iob_signal import iob_signal, iob_signal_reference
 from iob_globals import iob_globals
 from api_base import internal_api_class
+from iob_base import parse_short_notation_text
 
 mem_if_details = [
     {
@@ -1820,26 +1821,29 @@ class wishboneInterface(interface):
 
 
 def create_interface(
-    genre,
-    if_direction="",
-    mult=1,
-    widths={},
-    params=None,
+    genre: str,
+    if_direction: str = "",
+    mult: int | str = 1,
+    widths: dict = {},
+    params: list = None,
     prefix="",
     portmap_port_prefix="",
     file_prefix="",
 ):
     """Creates an interface with the given genre and parameters.
-    param genre: Name of the interface.
-    param if_direction: Direction of the interface.
-                Examples: '' (unspecified), 'manager', 'subordinate', ...
-    param mult: Multiplication factor for all signal widths.
-    param widths: Dictionary for configuration of specific signal widths.
-    param params: Dictionary for configuration of specific parameters.
-    param prefix: Prefix to add to all signal names.
-    param portmap_port_prefix: Prefix to add to all portmap ports.
-    param file_prefix: Prefix to add to the file name.
-    return: An instance of the interface class.
+    Attributes:
+        genre (str): Name of the interface.
+        if_direction (str): Direction of the interface.
+            Examples: '' (unspecified), 'manager', 'subordinate', ...
+        mult (int|str): Multiplication factor for all signal widths.
+        widths (dict): Dictionary for configuration of specific signal widths.
+        params (list): List for configuration of specific parameters.
+        prefix (str): Prefix to add to all signal names.
+        portmap_port_prefix (str): Prefix to add to all portmap ports.
+        file_prefix (str): Prefix to add to the file name.
+
+    Returns:
+        interface (interface): An instance of the interface class.
     Raises ValueError if the genre is not recognized or if the widths are not of the correct.
     """
 
@@ -2165,10 +2169,28 @@ if __name__ == "__main__":
 
 
 def interface_from_dict(interface_dict):
-    return interface(**interface_dict)
+    return create_interface(**interface_dict)
 
 
 def interface_from_text(interface_text):
-    interface_dict = {}
-    # TODO: parse short notation text
-    return interface(**interface_dict)
+    interface_flags = [
+        "genre",
+        ["-d", {"dest": "if_direction", "choices": ["", "manager", "subordinate"]}],
+        ["-m", {"dest": "mult"}],
+        ["-w", {"dest": "widths", "action": "append"}],  # create accepts dictionary
+        ["-P", {"dest": "params", "action": "append"}],
+        ["-p", {"dest": "prefix", "type": str}],
+        ["-pm", {"dest": "portmap_port_prefix", "type": str}],
+        ["-f", {"dest": "file_prefix", "type": str}],
+    ]
+    interface_dict = parse_short_notation_text(interface_text, interface_flags)
+    width_dict = {}
+    if "widths" in interface_dict and interface_dict["widths"]:
+        for width in interface_dict["widths"]:
+            if ":" in width:
+                w_key, value = width.split(":", 1)
+                width_dict[w_key] = value
+            else:
+                raise ValueError(f"Invalid width specification: {width}")
+    interface_dict.update({"widths": width_dict})
+    return create_interface(**interface_dict)

--- a/py2hwsw/scripts/iob_base.py
+++ b/py2hwsw/scripts/iob_base.py
@@ -773,4 +773,7 @@ def parse_short_notation_text(text: str, flags) -> dict:
     # create argument parser
     parser = create_short_notation_parser(flags)
     # parse and return text as dict
-    return parser.parse_args(pre_process_conf_text).__dict__
+    parsed_dict = parser.parse_args(pre_process_conf_text).__dict__
+    # filter out None values, no need to set default values for arguments
+    filtered_dict = {k: v for k, v in parsed_dict.items() if v is not None}
+    return filtered_dict

--- a/py2hwsw/scripts/iob_base.py
+++ b/py2hwsw/scripts/iob_base.py
@@ -759,6 +759,38 @@ def create_short_notation_parser(flags: list) -> argparse.ArgumentParser:
     return parser
 
 
+def process_short_notation(text: str):
+    """Process short notation.
+    Perform correct string escaping and parsing of nested structures.
+    Use '{{' and '}}' to denote nested structures.
+    Attributes:
+        text (str): input string containing the short notation.
+            Example:
+                L1
+                -d 'Level 1 descr'
+                -l2
+                {{
+                    -d 'Level 2 descr'
+                    -l3
+                    {{
+                        -d 'Level 3 descr'
+                        -v val3
+                    }}
+                    -P L2_W
+                }}
+                -P L1_W
+
+    Returns:
+        str: processed string with correct escaping and parsing.
+    """
+    if "{{" in text and "}}" in text:
+        prefix, parts = text.split("{{", maxsplit=1)
+        substr, sufix = parts.rsplit("}}", maxsplit=1)
+        escaped_substr = shlex.quote(process_short_notation(substr))
+        return f"{prefix}{escaped_substr}{sufix}"
+    return text
+
+
 def parse_short_notation_text(text: str, flags) -> dict:
     """Parse Short Notation Text
     Arguments:
@@ -769,7 +801,8 @@ def parse_short_notation_text(text: str, flags) -> dict:
         dict: Parsed short text as flags dictionary.
     """
     # preprocess short notation text
-    pre_process_conf_text = shlex.split(text.strip('\n'))
+    escaped_text = process_short_notation(text)
+    pre_process_conf_text = shlex.split(escaped_text.strip('\n'))
     # create argument parser
     parser = create_short_notation_parser(flags)
     # parse and return text as dict

--- a/py2hwsw/scripts/iob_comb.py
+++ b/py2hwsw/scripts/iob_comb.py
@@ -274,12 +274,15 @@ def comb_from_dict(comb_dict):
     return iob_comb(**comb_dict)
 
 
-def comb_from_text(comb_text):
+def comb_text2dict(comb_text):
     comb_flags = [
         ["-c", {"dest": "code"}],
         ["-clk_if", {"dest": "clk_if"}],
         ["-clk_p", {"dest": "clk_prefix"}],
     ]
     # Parse comb text into a dictionary
-    comb_dict = parse_short_notation_text(comb_text, comb_flags)
-    return iob_comb(**comb_dict)
+    return parse_short_notation_text(comb_text, comb_flags)
+
+
+def comb_from_text(comb_text):
+    return comb_from_dict(comb_text2dict(comb_text))

--- a/py2hwsw/scripts/iob_comb.py
+++ b/py2hwsw/scripts/iob_comb.py
@@ -6,7 +6,7 @@ import re
 
 from dataclasses import dataclass
 from iob_snippet import iob_snippet
-from iob_base import fail_with_msg, assert_attributes
+from iob_base import fail_with_msg, assert_attributes, parse_short_notation_text
 from iob_wire import find_signal_in_wires
 from iob_signal import get_real_signal
 from interfaces import iobClkInterface
@@ -275,6 +275,11 @@ def comb_from_dict(comb_dict):
 
 
 def comb_from_text(comb_text):
-    comb_dict = {}
-    # TODO: parse short notation text
+    comb_flags = [
+        ["-c", {"dest": "code"}],
+        ["-clk_if", {"dest": "clk_if"}],
+        ["-clk_p", {"dest": "clk_prefix"}],
+    ]
+    # Parse comb text into a dictionary
+    comb_dict = parse_short_notation_text(comb_text, comb_flags)
     return iob_comb(**comb_dict)

--- a/py2hwsw/scripts/iob_conf.py
+++ b/py2hwsw/scripts/iob_conf.py
@@ -161,7 +161,7 @@ def conf_from_dict(conf_dict):
     return conf_obj
 
 
-def conf_from_text(conf_text: str) -> iob_conf:
+def conf_text2dict(conf_text: str) -> dict:
     # parse conf text into a dictionary
     conf_text_flags = [
         "name",
@@ -172,8 +172,11 @@ def conf_from_text(conf_text: str) -> iob_conf:
         ["-d", {"dest": "descr", "nargs": "?"}],
         ["-doc", {"dest": "doc_only", "action": "store_true"}],
     ]
-    conf_dict = parse_short_notation_text(conf_text, conf_text_flags)
-    return iob_conf(**conf_dict)
+    return parse_short_notation_text(conf_text, conf_text_flags)
+
+
+def conf_from_text(conf_text: str) -> iob_conf:
+    return conf_from_dict(conf_text2dict(conf_text))
 
 
 def conf_group_from_dict(conf_group_dict):
@@ -203,7 +206,7 @@ def conf_group_from_dict(conf_group_dict):
     return conf_group_obj
 
 
-def conf_group_from_text(conf_group_text: str):
+def conf_group_text2dict(conf_group_text: str) -> dict:
     # Create conf_group from short notation text
     conf_group_flags = [
         "name",
@@ -218,7 +221,11 @@ def conf_group_from_text(conf_group_text: str):
     # Special processing for conf subflags
     confs: list[iob_conf] = []
     for conf_text in conf_group_dict.get("confs", "").split("\n\n"):
-        confs.append(conf_from_text(conf_text))
+        confs.append(conf_text2dict(conf_text))
     # replace "confs" short notation text with list of conf objects
     conf_group_dict.update({"confs": confs})
-    return iob_conf_group(**conf_group_dict)
+    return conf_group_dict
+
+
+def conf_group_from_text(conf_group_text: str):
+    return conf_group_from_dict(conf_group_text2dict(conf_group_text))

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -1208,7 +1208,7 @@ def core_from_dict(core_dict):
     return iob_core(core_dict)
 
 
-def core_from_text(core_text):
+def core_text2dict(core_text):
     core_flags = [
         # iob_module attributes
         "original_name",
@@ -1254,4 +1254,8 @@ def core_from_text(core_text):
     #   - subblocks, superblocks, sw_modules
     #   - connect -> portmap_connections, parameters, ignore_snippets?
     #   - parent?, python_parameters
-    return core_from_dict(core_dict)
+    return core_dict
+
+
+def core_from_text(core_text):
+    return core_from_dict(core_text2dict(core_text))

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -1230,13 +1230,13 @@ def core_text2dict(core_text):
         ['-c', {'dest': 'connect', 'action': 'append'}],  # port:ext format
         ['--param', {'dest': 'parameters', 'action': 'append'}],  # PARAM:VALUE format
         ['--no-instantiate', {'dest': 'instantiate', 'action': 'store_false'}],
-        ['--dest_dir', {'dest': 'dest-dir'}],
+        ['--dest_dir', {'dest': 'dest_dir'}],
         # iob_core attributes
         ['-v', {'dest': 'version'}],
         ['--prev_v', {'dest': 'previous_version'}],
         ['--setup_dir', {'dest': 'setup_dir'}],
         ['--build_dir', {'dest': 'build_dir'}],
-        ['--use_netlist', {'dest': 'build_dir', 'action': 'store_true'}],
+        ['--use_netlist', {'dest': 'use_netlist', 'action': 'store_true'}],
         ['--system', {'dest': 'is_system', 'action': 'store_true'}],
         ['--board', {'dest': 'board_list', 'action': 'append'}],
         ['--ignore_snippet', {'dest': 'ignore_snippets', 'action': 'append'}],

--- a/py2hwsw/scripts/iob_core.py
+++ b/py2hwsw/scripts/iob_core.py
@@ -41,6 +41,7 @@ from iob_base import (
     debug,
     get_lib_cores,
     update_obj_from_dict,
+    parse_short_notation_text,
 )
 from iob_license import iob_license, update_license
 import sw_tools
@@ -1208,6 +1209,49 @@ def core_from_dict(core_dict):
 
 
 def core_from_text(core_text):
-    core_dict = {}
-    # TODO: parse short notation text
-    return iob_core(**core_dict)
+    core_flags = [
+        # iob_module attributes
+        "original_name",
+        "name",
+        ['-d', {'dest': 'descr'}],
+        ['--rst_pol', {'dest': 'rst_policy'}],
+        ['--conf', {'dest': 'confs', 'action': 'append'}],
+        ['--port', {'dest': 'ports', 'action': 'append'}],
+        ['--wire', {'dest': 'wires', 'action': 'append'}],
+        ['--snippet', {'dest': 'snippets', 'action': 'append'}],
+        ['--comb', {'dest': 'comb'}],
+        ['--fsm', {'dest': 'fsm'}],
+        ['--subblock', {'dest': 'subblocks', 'action': 'append'}],
+        ['--superblock', {'dest': 'superblocks', 'action': 'append'}],
+        ['--sw_module', {'dest': 'sw_modules', 'action': 'append'}],
+        # iob_instance attributes
+        ['--inst_name', {'dest': 'instance_name'}],
+        ['--inst_d', {'dest': 'instance_description'}],
+        ['-c', {'dest': 'connect', 'action': 'append'}],  # port:ext format
+        ['--param', {'dest': 'parameters', 'action': 'append'}],  # PARAM:VALUE format
+        ['--no-instantiate', {'dest': 'instantiate', 'action': 'store_false'}],
+        ['--dest_dir', {'dest': 'dest-dir'}],
+        # iob_core attributes
+        ['-v', {'dest': 'version'}],
+        ['--prev_v', {'dest': 'previous_version'}],
+        ['--setup_dir', {'dest': 'setup_dir'}],
+        ['--build_dir', {'dest': 'build_dir'}],
+        ['--use_netlist', {'dest': 'build_dir', 'action': 'store_true'}],
+        ['--system', {'dest': 'is_system', 'action': 'store_true'}],
+        ['--board', {'dest': 'board_list', 'action': 'append'}],
+        ['--ignore_snippet', {'dest': 'ignore_snippets', 'action': 'append'}],
+        ['--gen_hw', {'dest': 'generate_hw', 'action': 'store_true'}],
+        ['--parent', {'dest': 'parent'}],
+        ['--tester', {'dest': 'is_tester', 'action': 'store_true'}],
+        ['--py_param', {'dest': 'python_parameters', 'action': 'append'}],
+        ['--lic', {'dest': 'license'}],
+        ['--doc_conf', {'dest': 'doc_conf'}],
+        ['--title', {'dest': 'title'}],
+    ]
+    core_dict = parse_short_notation_text(core_text, core_flags)
+    # TODO: process core_dict:
+    #   - confs, ports, wires, snippets, comb, fsm,
+    #   - subblocks, superblocks, sw_modules
+    #   - connect -> portmap_connections, parameters, ignore_snippets?
+    #   - parent?, python_parameters
+    return core_from_dict(core_dict)

--- a/py2hwsw/scripts/iob_fsm.py
+++ b/py2hwsw/scripts/iob_fsm.py
@@ -130,11 +130,14 @@ def fsm_from_dict(fsm_dict):
     return iob_fsm(**fsm_dict)
 
 
-def fsm_from_text(fsm_text):
+def fsm_text2dict(fsm_text):
     fsm_flags = [
         ['-t', {"dest": "kind", "choices": ["prog", "fsm"]}],
         ['-d', {"dest": "default_assignments"}],
         ['-s', {"dest": "state_descriptions"}],
     ]
-    fsm_dict = parse_short_notation_text(fsm_text, fsm_flags)
-    return iob_fsm(**fsm_dict)
+    return parse_short_notation_text(fsm_text, fsm_flags)
+
+
+def fsm_from_text(fsm_text):
+    return fsm_from_dict(fsm_text2dict(fsm_text))

--- a/py2hwsw/scripts/iob_fsm.py
+++ b/py2hwsw/scripts/iob_fsm.py
@@ -6,7 +6,7 @@ import re
 
 from dataclasses import dataclass
 from iob_comb import iob_comb
-from iob_base import assert_attributes
+from iob_base import assert_attributes, parse_short_notation_text
 
 
 from api_base import internal_api_class
@@ -131,6 +131,10 @@ def fsm_from_dict(fsm_dict):
 
 
 def fsm_from_text(fsm_text):
-    fsm_dict = {}
-    # TODO: parse short notation text
+    fsm_flags = [
+        ['-t', {"dest": "kind", "choices": ["prog", "fsm"]}],
+        ['-d', {"dest": "default_assignments"}],
+        ['-s', {"dest": "state_descriptions"}],
+    ]
+    fsm_dict = parse_short_notation_text(fsm_text, fsm_flags)
     return iob_fsm(**fsm_dict)

--- a/py2hwsw/scripts/iob_license.py
+++ b/py2hwsw/scripts/iob_license.py
@@ -35,11 +35,14 @@ def license_from_dict(license_dict):
     return iob_license(**license_dict)
 
 
-def license_from_text(license_text):
+def license_text2dict(license_text):
     license_flags = [
         "name",
         ["-y", {"dest": "year"}],
         ["-a", {"dest": "author"}],
     ]
-    license_dict = parse_short_notation_text(license_text, license_flags)
-    return iob_license(**license_dict)
+    return parse_short_notation_text(license_text, license_flags)
+
+
+def license_from_text(license_text):
+    return license_from_dict(license_text2dict(license_text))

--- a/py2hwsw/scripts/iob_license.py
+++ b/py2hwsw/scripts/iob_license.py
@@ -38,7 +38,7 @@ def license_from_dict(license_dict):
 def license_text2dict(license_text):
     license_flags = [
         "name",
-        ["-y", {"dest": "year"}],
+        ["-y", {"dest": "year", "type": int}],
         ["-a", {"dest": "author"}],
     ]
     return parse_short_notation_text(license_text, license_flags)

--- a/py2hwsw/scripts/iob_license.py
+++ b/py2hwsw/scripts/iob_license.py
@@ -3,10 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 from dataclasses import dataclass
-from datetime import date
 
-from iob_base import fail_with_msg
-
+from iob_base import fail_with_msg, parse_short_notation_text
 
 from api_base import internal_api_class
 
@@ -38,6 +36,10 @@ def license_from_dict(license_dict):
 
 
 def license_from_text(license_text):
-    license_dict = {}
-    # TODO: parse short notation text
+    license_flags = [
+        "name",
+        ["-y", {"dest": "year"}],
+        ["-a", {"dest": "author"}],
+    ]
+    license_dict = parse_short_notation_text(license_text, license_flags)
     return iob_license(**license_dict)

--- a/py2hwsw/scripts/iob_port.py
+++ b/py2hwsw/scripts/iob_port.py
@@ -204,7 +204,7 @@ def port_from_dict(port_dict):
     return port_obj
 
 
-def port_from_text(port_text):
+def port_text2dict(port_text):
     port_flags = [
         "name",
         ["-i", {"dest": "interface"}],
@@ -225,4 +225,8 @@ def port_from_text(port_text):
             )
         port_signals.append(signal_from_dict({"name": s_name, "width": s_width}))
     port_dict.update({"signals": port_signals})
-    return iob_port(**port_dict)
+    return port_dict
+
+
+def port_from_text(port_text):
+    return port_from_dict(port_text2dict(port_text))

--- a/py2hwsw/scripts/iob_port.py
+++ b/py2hwsw/scripts/iob_port.py
@@ -223,7 +223,7 @@ def port_text2dict(port_text):
                 f"Invalid signal format '{s}'! Expected 'name:width' format.",
                 ValueError,
             )
-        port_signals.append(signal_from_dict({"name": s_name, "width": s_width}))
+        port_signals.append({"name": s_name, "width": s_width})
     port_dict.update({"signals": port_signals})
     return port_dict
 

--- a/py2hwsw/scripts/iob_python_parameter.py
+++ b/py2hwsw/scripts/iob_python_parameter.py
@@ -143,6 +143,7 @@ def python_parameter_group_text2dict(python_parameter_group_text):
         "name",
         ["-d", {"dest": "descr"}],
         ["-P", {"dest": "python_parameters", "action": "append"}],
+        ["-doc_clearpage", {"dest": "doc_clearpage", "action": "store_true"}],
     ]
     python_parameter_group_dict = parse_short_notation_text(
         python_parameter_group_text, python_parameter_group_flags

--- a/py2hwsw/scripts/iob_python_parameter.py
+++ b/py2hwsw/scripts/iob_python_parameter.py
@@ -106,16 +106,17 @@ def python_parameter_from_dict(python_parameter_dict):
     return iob_python_parameter(**python_parameter_dict)
 
 
-def python_parameter_from_text(python_parameter_text):
+def python_parameter_text2dict(python_parameter_text):
     python_parameter_flags = [
         "name",
         ["-v", {"dest": "val"}],
         ["-d", {"dest": "descr"}],
     ]
-    python_parameter_dict = parse_short_notation_text(
-        python_parameter_text, python_parameter_flags
-    )
-    return iob_python_parameter(**python_parameter_dict)
+    return parse_short_notation_text(python_parameter_text, python_parameter_flags)
+
+
+def python_parameter_from_text(python_parameter_text):
+    return python_parameter_from_dict(python_parameter_text2dict(python_parameter_text))
 
 
 def python_parameter_group_from_dict(python_parameter_group_dict):
@@ -137,7 +138,7 @@ def python_parameter_group_from_dict(python_parameter_group_dict):
     return python_parameter_group_obj
 
 
-def python_parameter_group_from_text(python_parameter_group_text):
+def python_parameter_group_text2dict(python_parameter_group_text):
     python_parameter_group_flags = [
         "name",
         ["-d", {"dest": "descr"}],
@@ -149,7 +150,13 @@ def python_parameter_group_from_text(python_parameter_group_text):
     # Special processing for python_parameter subflags
     params: list[iob_python_parameter] = []
     for param_text in python_parameter_group_dict.get("python_parameters", []):
-        params.append(python_parameter_from_text(param_text))
-    # replace "python_parameters" short notation text with list of python parameter objects
+        params.append(python_parameter_text2dict(param_text))
+    # replace "python_parameters" short notation text with list of python parameter dicts
     python_parameter_group_dict.update({"python_parameters": params})
-    return iob_python_parameter_group(**python_parameter_group_dict)
+    return python_parameter_group_dict
+
+
+def python_parameter_group_from_text(python_parameter_group_text):
+    return python_parameter_group_from_dict(
+        python_parameter_group_text2dict(python_parameter_group_text)
+    )

--- a/py2hwsw/scripts/iob_python_parameter.py
+++ b/py2hwsw/scripts/iob_python_parameter.py
@@ -138,5 +138,18 @@ def python_parameter_group_from_dict(python_parameter_group_dict):
 
 
 def python_parameter_group_from_text(python_parameter_group_text):
-    # TODO: parse short notation text
+    python_parameter_group_flags = [
+        "name",
+        ["-d", {"dest": "descr"}],
+        ["-P", {"dest": "python_parameters", "action": "append"}],
+    ]
+    python_parameter_group_dict = parse_short_notation_text(
+        python_parameter_group_text, python_parameter_group_flags
+    )
+    # Special processing for python_parameter subflags
+    params: list[iob_python_parameter] = []
+    for param_text in python_parameter_group_dict.get("python_parameters", []):
+        params.append(python_parameter_from_text(param_text))
+    # replace "python_parameters" short notation text with list of python parameter objects
+    python_parameter_group_dict.update({"python_parameters": params})
     return iob_python_parameter_group(**python_parameter_group_dict)

--- a/py2hwsw/scripts/iob_python_parameter.py
+++ b/py2hwsw/scripts/iob_python_parameter.py
@@ -12,6 +12,7 @@ from iob_base import (
     assert_attributes,
     find_obj_in_list,
     update_obj_from_dict,
+    parse_short_notation_text,
 )
 
 from api_base import internal_api_class
@@ -106,8 +107,14 @@ def python_parameter_from_dict(python_parameter_dict):
 
 
 def python_parameter_from_text(python_parameter_text):
-    python_parameter_dict = {}
-    # TODO: parse short notation text
+    python_parameter_flags = [
+        "name",
+        ["-v", {"dest": "val"}],
+        ["-d", {"dest": "descr"}],
+    ]
+    python_parameter_dict = parse_short_notation_text(
+        python_parameter_text, python_parameter_flags
+    )
     return iob_python_parameter(**python_parameter_dict)
 
 
@@ -131,6 +138,5 @@ def python_parameter_group_from_dict(python_parameter_group_dict):
 
 
 def python_parameter_group_from_text(python_parameter_group_text):
-    python_parameter_group_dict = {}
     # TODO: parse short notation text
     return iob_python_parameter_group(**python_parameter_group_dict)

--- a/py2hwsw/scripts/iob_signal.py
+++ b/py2hwsw/scripts/iob_signal.py
@@ -103,12 +103,15 @@ def signal_from_dict(signal_dict):
     return iob_signal(**signal_dict)
 
 
-def signal_from_text(signal_text):
+def signal_text2dict(signal_text):
     signal_flags = [
         "name",
         ["-w", {"dest": "width"}],
         ["-v", {"dest": "isvar", "action": "store_true"}],
         ["-d", {"dest": "descr", "nargs": "?"}],
     ]
-    signal_dict = parse_short_notation_text(signal_text, signal_flags)
-    return iob_signal(**signal_dict)
+    return parse_short_notation_text(signal_text, signal_flags)
+
+
+def signal_from_text(signal_text):
+    return signal_from_dict(signal_text2dict(signal_text))

--- a/py2hwsw/scripts/iob_snippet.py
+++ b/py2hwsw/scripts/iob_snippet.py
@@ -37,6 +37,9 @@ def snippet_from_dict(snippet_dict):
     return iob_snippet(**snippet_dict)
 
 
+def snippet_text2dict(snippet_text):
+    return {'verilog_code': snippet_text}
+
+
 def snippet_from_text(snippet_text):
-    # Snippet shot notation translation is direct
-    return iob_snippet(verilog_code=snippet_text)
+    return iob_snippet(snippet_text2dict(snippet_text))

--- a/py2hwsw/scripts/iob_snippet.py
+++ b/py2hwsw/scripts/iob_snippet.py
@@ -38,6 +38,5 @@ def snippet_from_dict(snippet_dict):
 
 
 def snippet_from_text(snippet_text):
-    snippet_dict = {}
-    # TODO: parse short notation text
-    return iob_snippet(**snippet_dict)
+    # Snippet shot notation translation is direct
+    return iob_snippet(verilog_code=snippet_text)

--- a/py2hwsw/scripts/iob_snippet.py
+++ b/py2hwsw/scripts/iob_snippet.py
@@ -42,4 +42,4 @@ def snippet_text2dict(snippet_text):
 
 
 def snippet_from_text(snippet_text):
-    return iob_snippet(snippet_text2dict(snippet_text))
+    return snippet_from_dict(snippet_text2dict(snippet_text))

--- a/py2hwsw/scripts/iob_wire.py
+++ b/py2hwsw/scripts/iob_wire.py
@@ -269,7 +269,7 @@ def wire_from_dict(wire_dict):
     return wire_obj
 
 
-def wire_from_text(wire_text):
+def wire_text2dict(wire_text):
     wire_flags = [
         "name",
         ["-i", {"dest": "interface"}],
@@ -288,4 +288,8 @@ def wire_from_text(wire_text):
             )
         wire_signals.append(signal_from_dict({"name": s_name, "width": s_width}))
     wire_dict.update({"signals": wire_signals})
-    return iob_wire(**wire_dict)
+    return wire_dict
+
+
+def wire_from_text(wire_text):
+    return wire_from_dict(wire_text2dict(wire_text))

--- a/py2hwsw/scripts/iob_wire.py
+++ b/py2hwsw/scripts/iob_wire.py
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass, field
-import re
-from typing import List
+from dataclasses import dataclass
 
 import interfaces
 from iob_base import (
@@ -22,7 +20,7 @@ from iob_signal import (
     iob_signal_reference,
     get_real_signal,
     signal_from_dict,
-    signal_from_text,
+    signal_text2dict,
 )
 
 from api_base import internal_api_class
@@ -286,7 +284,7 @@ def wire_text2dict(wire_text):
                 f"Invalid signal format '{s}'! Expected 'name:width' format.",
                 ValueError,
             )
-        wire_signals.append(signal_from_dict({"name": s_name, "width": s_width}))
+        wire_signals.append({"name": s_name, "width": s_width})
     wire_dict.update({"signals": wire_signals})
     return wire_dict
 

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -458,7 +458,9 @@ def create_port_from_text(port_text):
 
     Attributes:
         port_text (str): Short notation text. Object attributes are specified using the following format:
-            name [-i interface] [-d descr] [-s signal_name:width]+
+            name [-i interface] [-d descr] [-s signal_name:width]+ [-doc] [-doc_clearpage]
+            Example:
+                control -d 'control bus' -s start_i:1 -s done_o:1 -s cmd_i:CMD_W -doc
 
     Returns:
         iob_port: iob_port object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -879,7 +879,11 @@ def create_python_parameter_group_from_text(python_parameter_group_text):
 
     Attributes:
         python_parameter_group_text (str): Short notation text. Object attributes are specified using the following format:
-            TODO
+            [name] [-d descr] [-doc_clearpage] [-P python_parameters]+
+            Example:
+                param_group -d 'Group of parameters' -doc_clearpage
+                -P "param1 -v 42 -d 'Parameter 1 description'"
+                -P "OUTPUT_W -v DATA_W -d 'Data width'"
 
     Returns:
         iob_python_parameter_group: iob_python_parameter_group object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -696,7 +696,9 @@ def create_license_from_text(license_text):
 
     Attributes:
         license_text (str): Short notation text. Object attributes are specified using the following format:
-            TODO
+            [name] [-y year] [-a author]
+            Example:
+                MIT -y 2025 -a 'IObundle, Lda'
 
     Returns:
         iob_license: iob_license object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -206,14 +206,13 @@ def create_conf_group_from_text(conf_group_text):
                 -d 'Default group of confs'
                 -doc
                 -doc_clearpage
-                --confs
-                    "
+                --confs {{
                     DATA_W -t P -v 32 -m NA -M NA
                     -d 'Data bus width'
 
                     ADDR_W -t P -v 4 -m NA -M NA
                     -d 'Address width'
-                    "
+                }}
 
     Returns:
         iob_conf_group: iob_conf_group object
@@ -335,7 +334,9 @@ def create_interface_from_text(interface_text):
             genre [-d direction] [-p prefix] [-m mult] [-f file_prefix] [-pm portmap_port_prefix] [-w WIDTH_W:val]+ -[-P PARAM:val]+
             Examples:
                 axi -d manager -p cpu_ -m 1 -f ctrl_cpu_ -pm controller_
+
                 rom_sp -d subordinate -p boot_ -w ADDR_W:8 -w DATA_W:32
+
                 axis -p output_ -P 'has_tlast'
 
     Returns:
@@ -563,15 +564,13 @@ def create_comb_from_text(comb_text):
         comb_text (str): Short notation text. Object attributes are specified using the following format:
             [-c code] [-clk_if clk_if] [-clk_p clk_prefix]
             Example:
-                '
-                    -c
-                    "
-                        // Register data
-                        data_nxt = data;
-                    "
-                    -clk_if c_a_r
-                    -clk_p data_
-                '
+                -c
+                {{
+                    // Register data
+                    data_nxt = data;
+                }}
+                -clk_if c_a_r
+                -clk_p data_
 
     Returns:
         iob_comb: iob_comb object
@@ -630,7 +629,7 @@ def create_fsm_from_text(fsm_text):
                 -t fsm
                 -d 'a_o = 10;'
                 -s
-                '
+                {{
                     A: a_o = 0;
                     B: a_o = 1;
                     a_o = 2;
@@ -642,7 +641,7 @@ def create_fsm_from_text(fsm_text):
                     begin
                         pcnt_nxt = B;
                     end
-                '
+                }}
 
     Returns:
         iob_fsm: iob_fsm object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -529,6 +529,7 @@ class iob_comb(iob_snippet):
     Attributes:
         code (str): Verilog code string
         clk_if (str): Clock interface
+        clk_prefix (str): Clock interface prefix
     """
 
     code: str = ""
@@ -560,7 +561,17 @@ def create_comb_from_text(comb_text):
 
     Attributes:
         comb_text (str): Short notation text. Object attributes are specified using the following format:
-            TODO
+            [-c code] [-clk_if clk_if] [-clk_p clk_prefix]
+            Example:
+                '
+                    -c
+                    "
+                        // Register data
+                        data_nxt = data;
+                    "
+                    -clk_if c_a_r
+                    -clk_p data_
+                '
 
     Returns:
         iob_comb: iob_comb object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -332,7 +332,11 @@ def create_interface_from_text(interface_text):
 
     Attributes:
         interface_text (str): Short notation text. Object attributes are specified using the following format:
-            type [-p prefix] [-m mult] [-w width]
+            genre [-d direction] [-p prefix] [-m mult] [-f file_prefix] [-pm portmap_port_prefix] [-w WIDTH_W:val]+ -[-P PARAM:val]+
+            Examples:
+                axi -d manager -p cpu_ -m 1 -f ctrl_cpu_ -pm controller_
+                rom_sp -d subordinate -p boot_ -w ADDR_W:8 -w DATA_W:32
+                axis -p output_ -P 'has_tlast'
 
     Returns:
         interface: interface object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -508,7 +508,7 @@ def create_snippet_from_text(snippet_text):
 
     Attributes:
         snippet_text (str): Short notation text. Object attributes are specified using the following format:
-            TODO
+            [snippet_text]
 
     Returns:
         iob_snippet: iob_snippet object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -825,7 +825,9 @@ def create_python_parameter_from_text(python_parameter_text):
 
     Attributes:
         python_parameter_text (str): Short notation text. Object attributes are specified using the following format:
-            TODO
+            [name] [-v value] [-d descr]
+            Example:
+                my_param -v 42 -d 'My parameter description'
 
     Returns:
         iob_python_parameter: iob_python_parameter object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -625,7 +625,24 @@ def create_fsm_from_text(fsm_text):
 
     Attributes:
         fsm_text (str): Short notation text. Object attributes are specified using the following format:
-            TODO
+            [-t kind] [-d default_assignments] [-s state_descriptions]
+            Example:
+                -t fsm
+                -d 'a_o = 10;'
+                -s
+                '
+                    A: a_o = 0;
+                    B: a_o = 1;
+                    a_o = 2;
+                    if(a_o == 0)
+                    begin
+                        pcnt_nxt = A;
+                    end
+                    else
+                    begin
+                        pcnt_nxt = B;
+                    end
+                '
 
     Returns:
         iob_fsm: iob_fsm object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -134,6 +134,18 @@ def create_conf_from_dict(conf_dict):
     pass
 
 
+@api_for(internal_conf.conf_text2dict)
+def conf_text2dict(conf_text):
+    """Convert conf short notation text to dictionary.
+    Atributes:
+        conf_text (str): Short notation text. See `create_conf_from_text` for format.
+
+    Returns:
+        dict: Dictionary with conf attributes.
+    """
+    pass
+
+
 @api_for(internal_conf.conf_from_text)
 def create_conf_from_text(conf_text):
     """
@@ -189,6 +201,18 @@ def create_conf_group_from_dict(conf_group_dict):
 
     Returns:
         iob_conf_group: iob_conf_group object
+    """
+    pass
+
+
+@api_for(internal_conf.conf_group_text2dict)
+def conf_group_text2dict(conf_group_text):
+    """Convert conf_group short notation text to dictionary.
+    Atributes:
+        conf_group_text (str): Short notation text. See `create_conf_group_from_text` for format.
+
+    Returns:
+        dict: Dictionary with conf_group attributes.
     """
     pass
 
@@ -262,6 +286,18 @@ def create_signal_from_dict(signal_dict):
     pass
 
 
+@api_for(internal_signal.signal_text2dict)
+def signal_text2dict(signal_text):
+    """Convert signal short notation text to dictionary.
+    Atributes:
+        signal_text (str): Short notation text. See `create_signal_from_text` for format.
+
+    Returns:
+        dict: Dictionary with signal attributes.
+    """
+    pass
+
+
 @api_for(internal_signal.signal_from_text)
 def create_signal_from_text(signal_text):
     """
@@ -320,6 +356,18 @@ def create_interface_from_dict(interface_dict):
 
     Returns:
         interface: interface object
+    """
+    pass
+
+
+@api_for(internal_interface.interface_text2dict)
+def interface_text2dict(interface_text):
+    """Convert interface short notation text to dictionary.
+    Atributes:
+        interface_text (str): Short notation text. See `create_interface_from_text` for format.
+
+    Returns:
+        dict: Dictionary with interface attributes.
     """
     pass
 
@@ -398,6 +446,18 @@ def create_wire_from_dict(wire_dict):
     pass
 
 
+@api_for(internal_wire.wire_text2dict)
+def wire_text2dict(wire_text):
+    """Convert wire short notation text to dictionary.
+    Atributes:
+        wire_text (str): Short notation text. See `create_wire_from_text` for format.
+
+    Returns:
+        dict: Dictionary with wire attributes.
+    """
+    pass
+
+
 @api_for(internal_wire.wire_from_text)
 def create_wire_from_text(wire_text):
     """
@@ -452,6 +512,18 @@ def create_port_from_dict(port_dict):
     pass
 
 
+@api_for(internal_port.port_text2dict)
+def port_text2dict(port_text):
+    """Convert port short notation text to dictionary.
+    Atributes:
+        port_text (str): Short notation text. See `create_port_from_text` for format.
+
+    Returns:
+        dict: Dictionary with port attributes.
+    """
+    pass
+
+
 @api_for(internal_port.port_from_text)
 def create_port_from_text(port_text):
     """
@@ -498,6 +570,18 @@ def create_snippet_from_dict(snippet_dict):
 
     Returns:
         iob_snippet: iob_snippet object
+    """
+    pass
+
+
+@api_for(internal_snippet.snippet_text2dict)
+def snippet_text2dict(snippet_text):
+    """Convert snippet short notation text to dictionary.
+    Atributes:
+        snippet_text (str): Short notation text. See `create_snippet_from_text` for format.
+
+    Returns:
+        dict: Dictionary with snippet attributes.
     """
     pass
 
@@ -551,6 +635,18 @@ def create_comb_from_dict(comb_dict):
 
     Returns:
         iob_comb: iob_comb object
+    """
+    pass
+
+
+@api_for(internal_comb.comb_text2dict)
+def comb_text2dict(comb_text):
+    """Convert comb short notation text to dictionary.
+    Atributes:
+        comb_text (str): Short notation text. See `create_comb_from_text` for format.
+
+    Returns:
+        dict: Dictionary with comb attributes.
     """
     pass
 
@@ -613,6 +709,18 @@ def create_fsm_from_dict(fsm_dict):
 
     Returns:
         iob_fsm: iob_fsm object
+    """
+    pass
+
+
+@api_for(internal_fsm.fsm_text2dict)
+def fsm_text2dict(fsm_text):
+    """Convert fsm short notation text to dictionary.
+    Atributes:
+        fsm_text (str): Short notation text. See `create_fsm_from_text` for format.
+
+    Returns:
+        dict: Dictionary with fsm attributes.
     """
     pass
 
@@ -684,6 +792,18 @@ def create_license_from_dict(license_dict):
 
     Returns:
         iob_license: iob_license object
+    """
+    pass
+
+
+@api_for(internal_license.license_text2dict)
+def license_text2dict(license_text):
+    """Convert license short notation text to dictionary.
+    Atributes:
+        license_text (str): Short notation text. See `create_license_from_text` for format.
+
+    Returns:
+        dict: Dictionary with license attributes.
     """
     pass
 
@@ -817,6 +937,18 @@ def create_python_parameter_from_dict(python_parameter_dict):
     pass
 
 
+@api_for(internal_python_parameter.python_parameter_text2dict)
+def python_parameter_text2dict(python_parameter_text):
+    """Convert python_parameter short notation text to dictionary.
+    Atributes:
+        python_parameter_text (str): Short notation text. See `create_python_parameter_from_text` for format.
+
+    Returns:
+        dict: Dictionary with python_parameter attributes.
+    """
+    pass
+
+
 @api_for(internal_python_parameter.python_parameter_from_text)
 def create_python_parameter_from_text(python_parameter_text):
     """
@@ -867,6 +999,18 @@ def create_python_parameter_group_from_dict(python_parameter_group_dict):
 
     Returns:
         iob_python_parameter_group: iob_python_parameter_group object
+    """
+    pass
+
+
+@api_for(internal_python_parameter.python_parameter_group_text2dict)
+def python_parameter_group_text2dict(python_parameter_group_text):
+    """Convert python_parameter_group short notation text to dictionary.
+    Atributes:
+        python_parameter_group_text (str): Short notation text. See `create_python_parameter_group_from_text` for format.
+
+    Returns:
+        dict: Dictionary with python_parameter_group attributes.
     """
     pass
 
@@ -1076,6 +1220,18 @@ def create_core_from_dict(core_dict):
 
     Returns:
         iob_core: iob_core object
+    """
+    pass
+
+
+@api_for(internal_core.core_text2dict)
+def core_text2dict(core_text):
+    """Convert core short notation text to dictionary.
+    Atributes:
+        core_text (str): Short notation text. See `create_core_from_text` for format.
+
+    Returns:
+        dict: Dictionary with core attributes.
     """
     pass
 


### PR DESCRIPTION
initial short notation implementation for the classes:
- [x] interface
- [x] iob_port
- [x] iob_comb
- [x] iob_snippet
- [x] iob_fsm
- [x] iob_license
- [x] python_parameter
- [x] python_parameter_group
- [ ] iob_csrs
- [ ] iob_core
- [ ] iob_instance

Other tasks:
- [ ] interface class has some problems with inheritance for child classes
- [x] add `text2dict()` method for classes that support short notation,
   - update `create_from_text()` methods into: `short_notation` -> `dictionary` -> `create_from_dict()` pipeline
- [x] improve short notation syntax to support multiple short notation levels