### PR TITLE
Add show() command in py2hwsw_shell; Import lib cores into py2hwsw_shell

### DIFF
--- a/py2hwsw/scripts/py2hwsw_shell.py
+++ b/py2hwsw/scripts/py2hwsw_shell.py
@@ -8,13 +8,26 @@
 
 import code
 import sys
+import os
+
+from iob_base import get_lib_cores, import_python_module
 
 HELP_MSG = """\
 Py2HWSW Python Shell
 ------------------------------------------------------------------------
+
+To create IP cores using Py2HWSW refer to our exemples by typing:
+
+>>> show(example_name)
+
+Currently the following examples are available:
+
+iob_and: illustrates a basic module with a generic parameter
+iob_aoi: illustrates a structural description based on subblocks
+
+Type 'help(api) for a complete reference'
 Type 'exit' or 'quit' to exit the shell.
-------------------------------------------------------------------------
-Type help() for interactive help
+Type 'help' for this message.
 """
 
 
@@ -45,6 +58,17 @@ class Py2hwswShell(code.InteractiveConsole):
         print(HELP_MSG)
 
 
+def import_lib_cores(namespace: dict):
+    """Import lib cores into given python namespace"""
+    cores_paths = get_lib_cores()
+    for path in cores_paths:
+        module_name, file_extension = os.path.basename(path).split(".")
+        # Skip non-py files, like .json
+        if file_extension != "py":
+            continue
+        namespace[module_name] = import_python_module(path, module_name=module_name)
+
+
 # Create an instance of the custom shell
 def main():
     sys.ps1 = ">>> "
@@ -54,6 +78,7 @@ def main():
     exec("import py2hwsw_api as api", local_vars)
     exec("from py2hwsw_api import *", local_vars)
     local_vars["help"] = CustomFunction(help, HELP_MSG)
+    import_lib_cores(local_vars)
     shell = Py2hwswShell(locals=local_vars)
     shell.interact()
 

--- a/py2hwsw/scripts/py2hwsw_shell.py
+++ b/py2hwsw/scripts/py2hwsw_shell.py
@@ -77,6 +77,27 @@ def import_lib_cores(namespace: dict):
         namespace[module_name] = imported_module.__dict__[module_name]
 
 
+def show_lib_core_code(core_name: str = None):
+    if not core_name:
+        print(
+            "No lib core name given. Please provide a name, like: 'show(\"iob_and\")'."
+        )
+        return
+    if type(core_name) is not str:
+        print("Lib core name must be a string.")
+        return
+    cores_paths = get_lib_cores()
+    for path in cores_paths:
+        module_name, file_extension = os.path.basename(path).split(".")
+        if module_name == core_name:
+            print(f"Displaying code for {core_name} core")
+            with open(path, "r") as f:
+                print(f.read())
+            break
+    else:
+        print(f"Could not find lib core '{core_name}'.")
+
+
 # Create an instance of the custom shell
 def main():
     sys.ps1 = ">>> "
@@ -87,6 +108,7 @@ def main():
     exec("from py2hwsw_api import *", local_vars)
     local_vars["help"] = CustomFunction(help, HELP_MSG)
     import_lib_cores(local_vars)
+    local_vars["show"] = show_lib_core_code
     shell = Py2hwswShell(locals=local_vars)
     shell.interact()
 

--- a/py2hwsw/scripts/py2hwsw_shell.py
+++ b/py2hwsw/scripts/py2hwsw_shell.py
@@ -11,6 +11,7 @@ import sys
 import os
 
 from iob_base import get_lib_cores, import_python_module
+from iob_core import iob_core
 
 HELP_MSG = """\
 Py2HWSW Python Shell
@@ -63,10 +64,17 @@ def import_lib_cores(namespace: dict):
     cores_paths = get_lib_cores()
     for path in cores_paths:
         module_name, file_extension = os.path.basename(path).split(".")
-        # Skip non-py files, like .json
-        if file_extension != "py":
+        # Convert dictionaries from .json cores into dynamic subclass of iob_core
+        if file_extension == "json":
             continue
-        namespace[module_name] = import_python_module(path, module_name=module_name)
+        imported_module = import_python_module(path, module_name=module_name)
+
+        # FIXME: Temporarily only import a few modules (the ones that have a class defined inside)
+        if module_name not in ["iob_and", "iob_aoi"]:
+            continue
+
+        # Import only the class defined in that module
+        namespace[module_name] = imported_module.__dict__[module_name]
 
 
 # Create an instance of the custom shell

--- a/py2hwsw/scripts/py2hwsw_shell.py
+++ b/py2hwsw/scripts/py2hwsw_shell.py
@@ -19,7 +19,7 @@ Py2HWSW Python Shell
 
 To create IP cores using Py2HWSW refer to our exemples by typing:
 
->>> show(example_name)
+>>> show("example_name")
 
 Currently the following examples are available:
 

--- a/py2hwsw/scripts/py2hwsw_shell.py
+++ b/py2hwsw/scripts/py2hwsw_shell.py
@@ -26,7 +26,7 @@ Currently the following examples are available:
 iob_and: illustrates a basic module with a generic parameter
 iob_aoi: illustrates a structural description based on subblocks
 
-Type 'help(api) for a complete reference'
+Type 'help(api)' for a complete reference.
 Type 'exit' or 'quit' to exit the shell.
 Type 'help' for this message.
 """


### PR DESCRIPTION
- Add `show()` command in py2hwsw_shell.
  Usage `show("<lib_core_name>")` to print the code of the corresponding lib core's .py or .json file.
- Auto-import lib cores into py2hwsw_shell
  We can now run `help(iob_and)` and call the constructor for that class:
  `my_obj = iob_and(width=8)`