### PR TITLE
Refactor py2hwsw scripts; Improve docstrings.

### DIFF
--- a/py2hwsw/lib/hardware/arith_logic/iob_prng/iob_prng.py
+++ b/py2hwsw/lib/hardware/arith_logic/iob_prng/iob_prng.py
@@ -94,6 +94,7 @@ core_dictionary = {
     ],
 }
 
+
 class iob_prng(py2hwsw.iob_core):
     def __init__(self):
         print("[DEBUG]: iob_prng constructor called.")

--- a/py2hwsw/src/block_gen.py
+++ b/py2hwsw/src/block_gen.py
@@ -8,12 +8,13 @@
 
 from latex import write_table
 
-import iob_colors
-from iob_wire import get_real_wire
-from iob_port import port_obj_list_process
+from iob_wire import iob_wire
+from iob_port import iob_port
 import param_gen
 from iob_base import fail_with_msg, find_obj_in_list
-from iob_port import iob_port
+
+get_real_wire = iob_wire.get_real_wire
+port_obj_list_process = iob_port.port_obj_list_process
 
 
 # Generate subblocks.tex file with TeX table of subblocks (Verilog modules instances)

--- a/py2hwsw/src/iob_base.py
+++ b/py2hwsw/src/iob_base.py
@@ -826,6 +826,24 @@ def parse_short_notation_text(text: str, flags) -> dict:
     filtered_dict = {k: v for k, v in parsed_dict.items() if v is not None}
     return filtered_dict
 
+def find_common_deep(path1, path2):
+    """Find common files (recursively) inside two given directories
+    Taken from: https://stackoverflow.com/a/51625515
+    :param str path1: Directory path 1
+    :param str path2: Directory path 2
+    """
+    return set.intersection(
+        *(
+            set(
+                os.path.relpath(os.path.join(root, file), path)
+                for root, _, files in os.walk(path)
+                for file in files
+            )
+            for path in (path1, path2)
+        )
+    )
+
+
 #
 # Utility functions
 #

--- a/py2hwsw/src/iob_bus.py
+++ b/py2hwsw/src/iob_bus.py
@@ -10,17 +10,14 @@ from iob_base import (
     create_obj_list,
     fail_with_msg,
     add_traceback_msg,
-    str_to_kwargs,
     assert_attributes,
     parse_short_notation_text,
     empty_list,
 )
-from iob_wire import (
-    iob_wire,
-    iob_wire_reference,
-    get_real_wire,
-    create_wire_from_dict,
-)
+from iob_wire import iob_wire, iob_wire_reference
+
+get_real_wire = iob_wire.get_real_wire
+create_wire_from_dict = iob_wire.create_wire_from_dict
 
 
 @dataclass
@@ -74,248 +71,253 @@ class iob_bus:
         if not self.name:
             fail_with_msg("All buses must have a name!", ValueError)
 
-
-attrs = [
-    "name",
-    ["-i", "wires&i", {"nargs": 1}, ("type",)],
-    ["-s", "wires&s", {"nargs": "+"}, ["name:width"]],
-]
-
-
-@str_to_kwargs(attrs)
-def create_bus(core, *args, wires=[], **kwargs):
-    """Creates a new bus object and adds it to the core's bus list
-    param core: core object
-    """
-    try:
-        # Ensure 'buses' list exists
-        core.set_default_attribute("buses", [])
-        # Check if there are any references to wires in other buses/ports
-        sig_obj_list = []
-        interface_obj = None
-        if type(wires) is list:
-            # Convert user wire dictionaries into 'iob_wire' objects
-            replace_duplicate_wires_by_references(core.buses + core.ports, wires)
-            sig_obj_list = create_obj_list(wires, iob_wire)
-        elif type(wires) is dict:
-            # Convert user interface dictionary into '_interface' object
-            interface_obj = dict2interface(
-                name=kwargs.get("name", ""), interface_dict=wires
-            )
-            if interface_obj and not interface_obj.file_prefix:
-                interface_obj.file_prefix = core.name + "_"
-        else:
-            fail_with_msg(f"Invalid wire type! {wires}", TypeError)
-        assert_attributes(
-            iob_bus,
-            kwargs,
-            error_msg=f"Invalid {kwargs.get('name', '')} bus attribute '[arg]'!",
-        )
-        bus = iob_bus(*args, wires=sig_obj_list, interface=interface_obj, **kwargs)
-        replace_duplicate_wires_by_references(core.buses + core.ports, bus.wires)
-        core.buses.append(bus)
-    except Exception:
-        add_traceback_msg(f"Failed to create bus '{kwargs['name']}'.")
-        raise
-
-
-def get_bus_wire(core, bus_name: str, wire_name: str):
-    """Return a wire reference from a given bus.
-    param core: core object
-    param bus_name: name of bus in the core's local bus list
-    param wire_name: name of wire in the bus's wire list
-    """
-    bus = find_obj_in_list(core.buses, bus_name) or find_obj_in_list(
-        core.ports, bus_name
-    )
-    if not bus:
-        fail_with_msg(f"Could not find bus/port '{bus_name}'!")
-
-    wire = find_obj_in_list(bus.wires, wire_name, process_func=get_real_wire)
-    if not wire:
-        fail_with_msg(f"Could not find wire '{wire_name}' of bus/port '{bus_name}'!")
-
-    return iob_wire_reference(wire=wire)
-
-
-def replace_duplicate_wires_by_references(buses, wires):
-    """Ensure that given list of 'wires' does not contain duplicates of other wires
-    in the given 'buses' list, by replacing the duplicates with references to the
-    original.
-    param buses: list of buses with (original) wires
-    param wires: list of new wires to be processed. If this list has a wire with
-    the same name as another wire in the buses list, then this wire is replaced by a
-    reference to the original.
-    """
-    for idx, wire in enumerate(wires):
-        if isinstance(wire, iob_wire_reference):
-            continue
-        if type(wire) is iob_wire:
-            wire = wire.__dict__
-        original_wire = find_wire_in_buses(buses, wire["name"])
-        if not original_wire:
-            continue
-        original_wire = get_real_wire(original_wire)
-        # print(f"[DEBUG] Replacing wire '{wire['name']}' by reference to original.")
-        # Verify that new wire has same parameters as the original_wire
-        for key, value in wire.items():
-            if original_wire.__dict__[key] != value:
-                fail_with_msg(
-                    f"Wire reference '{wire['name']}' has different '{key}' than the original wire!\n"
-                    f"Original wire '{original_wire.name}' value: '{original_wire.__dict__[key]}'.\n"
-                    f"Wire reference '{wire['name']}' value: '{value}'."
+    # attrs = [
+    #     "name",
+    #     ["-i", "wires&i", {"nargs": 1}, ("type",)],
+    #     ["-s", "wires&s", {"nargs": "+"}, ["name:width"]],
+    # ]
+    #
+    #
+    #     @str_to_kwargs(attrs)
+    @staticmethod
+    def create_bus(core, *args, wires=[], **kwargs):
+        """Creates a new bus object and adds it to the core's bus list
+        param core: core object
+        """
+        try:
+            # Ensure 'buses' list exists
+            core.set_default_attribute("buses", [])
+            # Check if there are any references to wires in other buses/ports
+            sig_obj_list = []
+            interface_obj = None
+            if type(wires) is list:
+                # Convert user wire dictionaries into 'iob_wire' objects
+                __class__.replace_duplicate_wires_by_references(
+                    core.buses + core.ports, wires
                 )
-        # Replace wire by a reference to the original
-        wires[idx] = iob_wire_reference(wire=original_wire)
+                sig_obj_list = create_obj_list(wires, iob_wire)
+            elif type(wires) is dict:
+                # Convert user interface dictionary into '_interface' object
+                interface_obj = __class__.dict2interface(
+                    name=kwargs.get("name", ""), interface_dict=wires
+                )
+                if interface_obj and not interface_obj.file_prefix:
+                    interface_obj.file_prefix = core.name + "_"
+            else:
+                fail_with_msg(f"Invalid wire type! {wires}", TypeError)
+            assert_attributes(
+                iob_bus,
+                kwargs,
+                error_msg=f"Invalid {kwargs.get('name', '')} bus attribute '[arg]'!",
+            )
+            bus = iob_bus(*args, wires=sig_obj_list, interface=interface_obj, **kwargs)
+            __class__.replace_duplicate_wires_by_references(
+                core.buses + core.ports, bus.wires
+            )
+            core.buses.append(bus)
+        except Exception:
+            add_traceback_msg(f"Failed to create bus '{kwargs['name']}'.")
+            raise
 
+    @staticmethod
+    def get_bus_wire(core, bus_name: str, wire_name: str):
+        """Return a wire reference from a given bus.
+        param core: core object
+        param bus_name: name of bus in the core's local bus list
+        param wire_name: name of wire in the bus's wire list
+        """
+        bus = find_obj_in_list(core.buses, bus_name) or find_obj_in_list(
+            core.ports, bus_name
+        )
+        if not bus:
+            fail_with_msg(f"Could not find bus/port '{bus_name}'!")
 
-def find_wire_in_buses(buses, wire_name, process_func=get_real_wire):
-    """Search for a wire in given list of buses
-    param buses: list of buses
-    param wire_name: name of wire to search for
-    param process_func: function to process each wire before search
-    """
-    for bus in buses:
-        wire = find_obj_in_list(bus.wires, wire_name, process_func=process_func)
-        if wire:
-            return wire
-    return None
+        wire = find_obj_in_list(bus.wires, wire_name, process_func=get_real_wire)
+        if not wire:
+            fail_with_msg(
+                f"Could not find wire '{wire_name}' of bus/port '{bus_name}'!"
+            )
 
+        return iob_wire_reference(wire=wire)
 
-#
-# Convert interface dictionary to an interface object
-# Note: This function is to be deprecated in the future, since objects should be created directly for
-# each interface type.
-#
-def dict2interface(name, interface_dict):
-    """Convert dictionary to an interface.
-    Example interface dict:
-    {
-        "type": "iob",
-        # Generic string parameter
-        "params": "",
-        # Widths/Other parameters
-        "DATA_W": "DATA_W",
-        "ADDR_W": "ADDR_W",
-    }
-    To use an assymmetric memory interface, the dictionary should look like this:
-    {
-        "type": "ram_at2p",
-        # Generic string parameter
-        "params": "",
-        # Widths/Other parameters
-        "ADDR_W": "ADDR_W",
-        "W_DATA_W": "W_DATA_W",
-        "R_DATA_W": "R_DATA_W",
-    }
-    """
-    if not interface_dict:
+    @staticmethod
+    def replace_duplicate_wires_by_references(buses, wires):
+        """Ensure that given list of 'wires' does not contain duplicates of other wires
+        in the given 'buses' list, by replacing the duplicates with references to the
+        original.
+        param buses: list of buses with (original) wires
+        param wires: list of new wires to be processed. If this list has a wire with
+        the same name as another wire in the buses list, then this wire is replaced by a
+        reference to the original.
+        """
+        for idx, wire in enumerate(wires):
+            if isinstance(wire, iob_wire_reference):
+                continue
+            if type(wire) is iob_wire:
+                wire = wire.__dict__
+            original_wire = __class__.find_wire_in_buses(buses, wire["name"])
+            if not original_wire:
+                continue
+            original_wire = get_real_wire(original_wire)
+            # print(f"[DEBUG] Replacing wire '{wire['name']}' by reference to original.")
+            # Verify that new wire has same parameters as the original_wire
+            for key, value in wire.items():
+                if original_wire.__dict__[key] != value:
+                    fail_with_msg(
+                        f"Wire reference '{wire['name']}' has different '{key}' than the original wire!\n"
+                        f"Original wire '{original_wire.name}' value: '{original_wire.__dict__[key]}'.\n"
+                        f"Wire reference '{wire['name']}' value: '{value}'."
+                    )
+            # Replace wire by a reference to the original
+            wires[idx] = iob_wire_reference(wire=original_wire)
+
+    @staticmethod
+    def find_wire_in_buses(buses, wire_name, process_func=get_real_wire):
+        """Search for a wire in given list of buses
+        param buses: list of buses
+        param wire_name: name of wire to search for
+        param process_func: function to process each wire before search
+        """
+        for bus in buses:
+            wire = find_obj_in_list(bus.wires, wire_name, process_func=process_func)
+            if wire:
+                return wire
         return None
 
-    genre = interface_dict.get("type", "")
+    #
+    # Convert interface dictionary to an interface object
+    # Note: This function is to be deprecated in the future, since objects should be created directly for
+    # each interface type.
+    #
+    @staticmethod
+    def dict2interface(name, interface_dict):
+        """Convert dictionary to an interface.
+        Example interface dict:
+        {
+            "type": "iob",
+            # Generic string parameter
+            "params": "",
+            # Widths/Other parameters
+            "DATA_W": "DATA_W",
+            "ADDR_W": "ADDR_W",
+        }
+        To use an assymmetric memory interface, the dictionary should look like this:
+        {
+            "type": "ram_at2p",
+            # Generic string parameter
+            "params": "",
+            # Widths/Other parameters
+            "ADDR_W": "ADDR_W",
+            "W_DATA_W": "W_DATA_W",
+            "R_DATA_W": "R_DATA_W",
+        }
+        """
+        if not interface_dict:
+            return None
 
-    if name.endswith("_m"):
-        if_direction = "manager"
-    elif name.endswith("_s"):
-        if_direction = "subordinate"
-    else:
-        if_direction = ""
+        genre = interface_dict.get("type", "")
 
-    prefix = interface_dict.get("prefix", "")
-    mult = interface_dict.get("mult", 1)
-    params = interface_dict.get("params", None)
-    if params is not None:
-        params = params.split("_")
-    file_prefix = interface_dict.get("file_prefix", "")
-    portmap_port_prefix = interface_dict.get("portmap_port_prefix", "")
+        if name.endswith("_m"):
+            if_direction = "manager"
+        elif name.endswith("_s"):
+            if_direction = "subordinate"
+        else:
+            if_direction = ""
 
-    # Remaining entries in the interface_dict (usually widths or other parameters)
-    remaining_entries = {
-        k: v
-        for k, v in interface_dict.items()
-        if k
-        not in [
-            "type",
-            "prefix",
-            "mult",
-            "params",
-            "file_prefix",
-            "portmap_port_prefix",
+        prefix = interface_dict.get("prefix", "")
+        mult = interface_dict.get("mult", 1)
+        params = interface_dict.get("params", None)
+        if params is not None:
+            params = params.split("_")
+        file_prefix = interface_dict.get("file_prefix", "")
+        portmap_port_prefix = interface_dict.get("portmap_port_prefix", "")
+
+        # Remaining entries in the interface_dict (usually widths or other parameters)
+        remaining_entries = {
+            k: v
+            for k, v in interface_dict.items()
+            if k
+            not in [
+                "type",
+                "prefix",
+                "mult",
+                "params",
+                "file_prefix",
+                "portmap_port_prefix",
+            ]
+        }
+
+        interface = iob_interface.create_interface(
+            genre=genre,
+            if_direction=if_direction,
+            mult=mult,
+            widths=remaining_entries,
+            prefix=prefix,
+            params=params,
+            portmap_port_prefix=portmap_port_prefix,
+            file_prefix=file_prefix,
+        )
+
+        return interface
+
+    #
+    # Other Py2HWSW interface methods
+    #
+
+    @staticmethod
+    def create_bus_from_dict(bus_dict):
+        """
+        Function to create iob_bus object from dictionary attributes.
+
+        Attributes:
+            bus_dict (dict): dictionary with values to initialize attributes of iob_bus object.
+                This dictionary supports the following keys corresponding to the iob_bus attributes:
+                - name           -> iob_bus.name
+                - descr          -> iob_bus.descr
+                - wires        -> iob_bus.wires
+
+        Returns:
+            iob_bus: iob_bus object
+        """
+        # Convert dictionary elements to objects
+        kwargs = bus_dict.copy()
+        kwargs["wires"] = [create_wire_from_dict(i) for i in bus_dict.get("wires", [])]
+        return iob_bus(**kwargs)
+
+    @staticmethod
+    def bus_text2dict(bus_text):
+        bus_flags = [
+            "name",
+            ["-i", {"dest": "interface"}],
+            ["-s", {"dest": "wires", "action": "append"}],
+            ["-d", {"dest": "descr", "nargs": "?"}],
         ]
-    }
+        bus_dict = parse_short_notation_text(bus_text, bus_flags)
+        bus_wires = []
+        for s in bus_dict.get("wires", []):
+            try:
+                [s_name, s_width] = s.split(":")
+            except ValueError:
+                fail_with_msg(
+                    f"Invalid wire format '{s}'! Expected 'name:width' format.",
+                    ValueError,
+                )
+            bus_wires.append({"name": s_name, "width": s_width})
+        bus_dict.update({"wires": bus_wires})
+        return bus_dict
 
-    interface = iob_interface.create_interface(
-        genre=genre,
-        if_direction=if_direction,
-        mult=mult,
-        widths=remaining_entries,
-        prefix=prefix,
-        params=params,
-        portmap_port_prefix=portmap_port_prefix,
-        file_prefix=file_prefix,
-    )
+    @staticmethod
+    def create_bus_from_text(bus_text):
+        """
+        Function to create iob_bus object from short notation text.
 
-    return interface
+        Attributes:
+            bus_text (str): Short notation text. Object attributes are specified using the following format:
+                name [-d descr] [-s wire_name1:width1] [-s wire_name2:width2]+
+                Examples:
+                    dbus -d 'data bus' -s wdata:32 -s wstrb:4
 
-
-#
-# Other Py2HWSW interface methods
-#
-
-
-def create_bus_from_dict(bus_dict):
-    """
-    Function to create iob_bus object from dictionary attributes.
-
-    Attributes:
-        bus_dict (dict): dictionary with values to initialize attributes of iob_bus object.
-            This dictionary supports the following keys corresponding to the iob_bus attributes:
-            - name           -> iob_bus.name
-            - descr          -> iob_bus.descr
-            - wires        -> iob_bus.wires
-
-    Returns:
-        iob_bus: iob_bus object
-    """
-    # Convert dictionary elements to objects
-    kwargs = bus_dict.copy()
-    kwargs["wires"] = [create_wire_from_dict(i) for i in bus_dict.get("wires", [])]
-    return iob_bus(**kwargs)
-
-
-def bus_text2dict(bus_text):
-    bus_flags = [
-        "name",
-        ["-i", {"dest": "interface"}],
-        ["-s", {"dest": "wires", "action": "append"}],
-        ["-d", {"dest": "descr", "nargs": "?"}],
-    ]
-    bus_dict = parse_short_notation_text(bus_text, bus_flags)
-    bus_wires = []
-    for s in bus_dict.get("wires", []):
-        try:
-            [s_name, s_width] = s.split(":")
-        except ValueError:
-            fail_with_msg(
-                f"Invalid wire format '{s}'! Expected 'name:width' format.",
-                ValueError,
-            )
-        bus_wires.append({"name": s_name, "width": s_width})
-    bus_dict.update({"wires": bus_wires})
-    return bus_dict
-
-
-def create_bus_from_text(bus_text):
-    """
-    Function to create iob_bus object from short notation text.
-
-    Attributes:
-        bus_text (str): Short notation text. Object attributes are specified using the following format:
-            name [-d descr] [-s wire_name1:width1] [-s wire_name2:width2]+
-            Examples:
-                dbus -d 'data bus' -s wdata:32 -s wstrb:4
-
-    Returns:
-        iob_bus: iob_bus object
-    """
-    return create_bus_from_dict(bus_text2dict(bus_text))
+        Returns:
+            iob_bus: iob_bus object
+        """
+        return __class__.create_bus_from_dict(__class__.bus_text2dict(bus_text))

--- a/py2hwsw/src/iob_bus.py
+++ b/py2hwsw/src/iob_bus.py
@@ -17,7 +17,6 @@ from iob_base import (
 from iob_wire import iob_wire, iob_wire_reference
 
 get_real_wire = iob_wire.get_real_wire
-create_wire_from_dict = iob_wire.create_wire_from_dict
 
 
 @dataclass
@@ -265,7 +264,7 @@ class iob_bus:
     #
 
     @staticmethod
-    def create_bus_from_dict(bus_dict):
+    def create_from_dict(bus_dict):
         """
         Function to create iob_bus object from dictionary attributes.
 
@@ -281,7 +280,9 @@ class iob_bus:
         """
         # Convert dictionary elements to objects
         kwargs = bus_dict.copy()
-        kwargs["wires"] = [create_wire_from_dict(i) for i in bus_dict.get("wires", [])]
+        kwargs["wires"] = [
+            iob_wire.create_from_dict(i) for i in bus_dict.get("wires", [])
+        ]
         return iob_bus(**kwargs)
 
     @staticmethod
@@ -307,7 +308,7 @@ class iob_bus:
         return bus_dict
 
     @staticmethod
-    def create_bus_from_text(bus_text):
+    def create_from_text(bus_text):
         """
         Function to create iob_bus object from short notation text.
 
@@ -320,4 +321,4 @@ class iob_bus:
         Returns:
             iob_bus: iob_bus object
         """
-        return __class__.create_bus_from_dict(__class__.bus_text2dict(bus_text))
+        return __class__.create_from_dict(__class__.bus_text2dict(bus_text))

--- a/py2hwsw/src/iob_comb.py
+++ b/py2hwsw/src/iob_comb.py
@@ -6,10 +6,13 @@ import re
 
 from dataclasses import dataclass
 from iob_snippet import iob_snippet
-from iob_base import fail_with_msg, assert_attributes, parse_short_notation_text
-from iob_bus import find_wire_in_buses
-from iob_wire import get_real_wire
+from iob_wire import iob_wire
+from iob_bus import iob_bus
 from iob_interface import iobClkInterface
+from iob_base import fail_with_msg, assert_attributes, parse_short_notation_text
+
+find_wire_in_buses = iob_bus.find_wire_in_buses
+get_real_wire = iob_wire.get_real_wire
 
 
 @dataclass
@@ -82,14 +85,14 @@ class iob_comb(iob_snippet):
                 wire = find_wire_in_buses(
                     core.ports,
                     wire_name,
-                    process_func=generate_direction_process_func("output"),
+                    process_func=__class__.generate_direction_process_func("output"),
                 )
                 wire.isvar = True
             elif wire_name.endswith("_io"):
                 wire = find_wire_in_buses(
                     core.ports,
                     wire_name,
-                    process_func=generate_direction_process_func("inout"),
+                    process_func=__class__.generate_direction_process_func("inout"),
                 )
                 wire.isvar = True
             elif wire_name.endswith("_nxt"):
@@ -254,96 +257,95 @@ class iob_comb(iob_snippet):
                             instance_description=f"{wire.name} register",
                         )
 
+    @staticmethod
+    def generate_direction_process_func(direction):
+        """Generates a process function that returns a wire if it matches the direction"""
 
-def generate_direction_process_func(direction):
-    """Generates a process function that returns a wire if it matches the direction"""
+        def filter_wire(wire):
+            wire = get_real_wire(wire)
+            if wire.direction == direction:
+                return wire
+            # Return empty object if not correct wire direction
+            return None
 
-    def filter_wire(wire):
-        wire = get_real_wire(wire)
-        if wire.direction == direction:
-            return wire
-        # Return empty object if not correct wire direction
-        return None
+        return filter_wire
 
-    return filter_wire
-
-
-def create_comb(core, *args, **kwargs):
-    """Create a Verilog combinatory circuit to insert in a given core."""
-    if core.fsm is not None:
-        raise ValueError(
-            "Comb circuits and FSMs are mutually exclusive. Use separate submodules."
+    @staticmethod
+    def create_comb(core, *args, **kwargs):
+        """Create a Verilog combinatory circuit to insert in a given core."""
+        if core.fsm is not None:
+            raise ValueError(
+                "Comb circuits and FSMs are mutually exclusive. Use separate submodules."
+            )
+        core.set_default_attribute("comb", None)
+        assert_attributes(
+            iob_comb,
+            kwargs,
+            error_msg=f"Invalid {kwargs.get('name', '')} comb attribute '[arg]'!",
         )
-    core.set_default_attribute("comb", None)
-    assert_attributes(
-        iob_comb,
-        kwargs,
-        error_msg=f"Invalid {kwargs.get('name', '')} comb attribute '[arg]'!",
-    )
-    # Get attributes from kwargs or use default from iob_comb
-    code = kwargs.get("code", "")
-    clk_if = kwargs.get("clk_if", "c_a")
-    comb = iob_comb(code=code, clk_if=clk_if)
-    comb.set_needed_reg(core)
-    comb.infer_registers(core)
-    core.comb = comb
+        # Get attributes from kwargs or use default from iob_comb
+        code = kwargs.get("code", "")
+        clk_if = kwargs.get("clk_if", "c_a")
+        comb = iob_comb(code=code, clk_if=clk_if)
+        comb.set_needed_reg(core)
+        comb.infer_registers(core)
+        core.comb = comb
 
+    #
+    # Other Py2HWSW interface methods
+    #
 
-#
-# Other Py2HWSW interface methods
-#
+    @staticmethod
+    def create_comb_from_dict(comb_dict):
+        """
+        Function to create iob_comb object from dictionary attributes.
 
+        Attributes:
+            comb_dict (dict): dictionary with values to initialize attributes of iob_comb object.
+                This dictionary supports the following keys corresponding to the iob_comb attributes:
+                - code -> iob_comb.code
+                - clk_if -> iob_comb.clk_if
 
-def create_comb_from_dict(comb_dict):
-    """
-    Function to create iob_comb object from dictionary attributes.
+        Returns:
+            iob_comb: iob_comb object
+        """
+        return iob_comb(**comb_dict)
 
-    Attributes:
-        comb_dict (dict): dictionary with values to initialize attributes of iob_comb object.
-            This dictionary supports the following keys corresponding to the iob_comb attributes:
-            - code -> iob_comb.code
-            - clk_if -> iob_comb.clk_if
+    @staticmethod
+    def comb_text2dict(comb_text):
+        """Convert comb short notation text to dictionary.
+        Atributes:
+            comb_text (str): Short notation text. See `create_comb_from_text` for format.
 
-    Returns:
-        iob_comb: iob_comb object
-    """
-    return iob_comb(**comb_dict)
+        Returns:
+            dict: Dictionary with comb attributes.
+        """
+        comb_flags = [
+            ["-c", {"dest": "code"}],
+            ["-clk_if", {"dest": "clk_if"}],
+            ["-clk_p", {"dest": "clk_prefix"}],
+        ]
+        # Parse comb text into a dictionary
+        return parse_short_notation_text(comb_text, comb_flags)
 
+    @staticmethod
+    def create_comb_from_text(comb_text):
+        """
+        Function to create iob_comb object from short notation text.
 
-def comb_text2dict(comb_text):
-    """Convert comb short notation text to dictionary.
-    Atributes:
-        comb_text (str): Short notation text. See `create_comb_from_text` for format.
+        Attributes:
+            comb_text (str): Short notation text. Object attributes are specified using the following format:
+                [-c code] [-clk_if clk_if] [-clk_p clk_prefix]
+                Example:
+                    -c
+                    {{
+                        // Register data
+                        data_nxt = data;
+                    }}
+                    -clk_if c_a_r
+                    -clk_p data_
 
-    Returns:
-        dict: Dictionary with comb attributes.
-    """
-    comb_flags = [
-        ["-c", {"dest": "code"}],
-        ["-clk_if", {"dest": "clk_if"}],
-        ["-clk_p", {"dest": "clk_prefix"}],
-    ]
-    # Parse comb text into a dictionary
-    return parse_short_notation_text(comb_text, comb_flags)
-
-
-def create_comb_from_text(comb_text):
-    """
-    Function to create iob_comb object from short notation text.
-
-    Attributes:
-        comb_text (str): Short notation text. Object attributes are specified using the following format:
-            [-c code] [-clk_if clk_if] [-clk_p clk_prefix]
-            Example:
-                -c
-                {{
-                    // Register data
-                    data_nxt = data;
-                }}
-                -clk_if c_a_r
-                -clk_p data_
-
-    Returns:
-        iob_comb: iob_comb object
-    """
-    return create_comb_from_dict(comb_text2dict(comb_text))
+        Returns:
+            iob_comb: iob_comb object
+        """
+        return __class__.create_comb_from_dict(__class__.comb_text2dict(comb_text))

--- a/py2hwsw/src/iob_comb.py
+++ b/py2hwsw/src/iob_comb.py
@@ -296,7 +296,7 @@ class iob_comb(iob_snippet):
     #
 
     @staticmethod
-    def create_comb_from_dict(comb_dict):
+    def create_from_dict(comb_dict):
         """
         Function to create iob_comb object from dictionary attributes.
 
@@ -315,7 +315,7 @@ class iob_comb(iob_snippet):
     def comb_text2dict(comb_text):
         """Convert comb short notation text to dictionary.
         Atributes:
-            comb_text (str): Short notation text. See `create_comb_from_text` for format.
+            comb_text (str): Short notation text. See `create_from_text` for format.
 
         Returns:
             dict: Dictionary with comb attributes.
@@ -329,7 +329,7 @@ class iob_comb(iob_snippet):
         return parse_short_notation_text(comb_text, comb_flags)
 
     @staticmethod
-    def create_comb_from_text(comb_text):
+    def create_from_text(comb_text):
         """
         Function to create iob_comb object from short notation text.
 
@@ -348,4 +348,4 @@ class iob_comb(iob_snippet):
         Returns:
             iob_comb: iob_comb object
         """
-        return __class__.create_comb_from_dict(__class__.comb_text2dict(comb_text))
+        return __class__.create_from_dict(__class__.comb_text2dict(comb_text))

--- a/py2hwsw/src/iob_conf.py
+++ b/py2hwsw/src/iob_conf.py
@@ -54,60 +54,59 @@ class iob_conf:
         except ValueError:
             pass
 
+    #
+    # Other Py2HWSW interface methods
+    #
 
-#
-# Other Py2HWSW interface methods
-#
+    @staticmethod
+    def create_conf_from_dict(conf_dict):
+        """
+        Function to create iob_conf object from dictionary attributes.
 
+        Attributes:
+            conf_dict (dict): dictionary with values to initialize attributes of iob_conf object.
+                This dictionary supports the following keys corresponding to the iob_conf attributes:
+                - name           -> iob_conf.name
+                - kind           -> iob_conf.kind
+                - value          -> iob_conf.value
+                - min_value      -> iob_conf.min_value
+                - max_value      -> iob_conf.max_value
+                - descr          -> iob_conf.descr
+                - doc_only       -> iob_conf.doc_only
 
-def create_conf_from_dict(conf_dict):
-    """
-    Function to create iob_conf object from dictionary attributes.
+        Returns:
+            iob_conf: iob_conf object
+        """
+        return iob_conf(**conf_dict)
 
-    Attributes:
-        conf_dict (dict): dictionary with values to initialize attributes of iob_conf object.
-            This dictionary supports the following keys corresponding to the iob_conf attributes:
-            - name           -> iob_conf.name
-            - kind           -> iob_conf.kind
-            - value          -> iob_conf.value
-            - min_value      -> iob_conf.min_value
-            - max_value      -> iob_conf.max_value
-            - descr          -> iob_conf.descr
-            - doc_only       -> iob_conf.doc_only
+    @staticmethod
+    def conf_text2dict(conf_text: str) -> dict:
+        # parse conf text into a dictionary
+        conf_text_flags = [
+            "name",
+            ["-t", {"dest": "kind"}],
+            ["-v", {"dest": "value"}],
+            ["-m", {"dest": "min_value"}],
+            ["-M", {"dest": "max_value"}],
+            ["-d", {"dest": "descr", "nargs": "?"}],
+            ["-doc", {"dest": "doc_only", "action": "store_true"}],
+        ]
+        return parse_short_notation_text(conf_text, conf_text_flags)
 
-    Returns:
-        iob_conf: iob_conf object
-    """
-    return iob_conf(**conf_dict)
+    @staticmethod
+    def create_conf_from_text(conf_text):
+        """
+        Function to create iob_conf object from short notation text.
 
+        Attributes:
+            conf_text (str): Short notation text. Object attributes are specified using the following format:
+                name [-t kind] [-v value] [-m min_value] [-M max_value] [-doc]
+                [-d descr]
+                Example:
+                    DATA_W -t P -v 32 -m NA -M NA
+                    -d 'Data bus width'
 
-def conf_text2dict(conf_text: str) -> dict:
-    # parse conf text into a dictionary
-    conf_text_flags = [
-        "name",
-        ["-t", {"dest": "kind"}],
-        ["-v", {"dest": "value"}],
-        ["-m", {"dest": "min_value"}],
-        ["-M", {"dest": "max_value"}],
-        ["-d", {"dest": "descr", "nargs": "?"}],
-        ["-doc", {"dest": "doc_only", "action": "store_true"}],
-    ]
-    return parse_short_notation_text(conf_text, conf_text_flags)
-
-
-def create_conf_from_text(conf_text):
-    """
-    Function to create iob_conf object from short notation text.
-
-    Attributes:
-        conf_text (str): Short notation text. Object attributes are specified using the following format:
-            name [-t kind] [-v value] [-m min_value] [-M max_value] [-doc]
-            [-d descr]
-            Example:
-                DATA_W -t P -v 32 -m NA -M NA
-                -d 'Data bus width'
-
-    Returns:
-        iob_conf: iob_conf object
-    """
-    return create_conf_from_dict(conf_text2dict(conf_text))
+        Returns:
+            iob_conf: iob_conf object
+        """
+        return __class__.create_conf_from_dict(__class__.conf_text2dict(conf_text))

--- a/py2hwsw/src/iob_conf.py
+++ b/py2hwsw/src/iob_conf.py
@@ -59,7 +59,7 @@ class iob_conf:
     #
 
     @staticmethod
-    def create_conf_from_dict(conf_dict):
+    def create_from_dict(conf_dict):
         """
         Function to create iob_conf object from dictionary attributes.
 
@@ -94,7 +94,7 @@ class iob_conf:
         return parse_short_notation_text(conf_text, conf_text_flags)
 
     @staticmethod
-    def create_conf_from_text(conf_text):
+    def create_from_text(conf_text):
         """
         Function to create iob_conf object from short notation text.
 
@@ -109,4 +109,4 @@ class iob_conf:
         Returns:
             iob_conf: iob_conf object
         """
-        return __class__.create_conf_from_dict(__class__.conf_text2dict(conf_text))
+        return __class__.create_from_dict(__class__.conf_text2dict(conf_text))

--- a/py2hwsw/src/iob_core.py
+++ b/py2hwsw/src/iob_core.py
@@ -31,24 +31,32 @@ from iob_base import (
     nix_permission_hack,
     update_obj_from_dict,
     parse_short_notation_text,
+    find_common_deep,
 )
 from py2hwsw_version import PY2HWSW_VERSION
-from iob_module import iob_module
 import sw_tools
 import verilog_format
 import verilog_lint
 from manage_headers import generate_headers
-from iob_license import iob_license
 
+from iob_module import iob_module
 from iob_comb import iob_comb
-from iob_conf import iob_conf, create_conf_from_dict
+from iob_conf import iob_conf
 from iob_fsm import iob_fsm
 from iob_interface import iob_interface
-from iob_wire import iob_wire, create_wire_from_dict
-from iob_port import iob_port, create_port_from_dict
-from iob_bus import iob_bus, create_bus_from_dict
-from iob_snippet import iob_snippet, create_snippet_from_dict
-from iob_parameter import create_iob_parameter_group_from_dict
+from iob_wire import iob_wire
+from iob_port import iob_port
+from iob_bus import iob_bus
+from iob_snippet import iob_snippet
+from iob_license import iob_license
+from iob_parameter import iob_parameter_group
+
+create_conf_from_dict = iob_conf.create_conf_from_dict
+create_wire_from_dict = iob_wire.create_wire_from_dict
+create_port_from_dict = iob_port.create_port_from_dict
+create_bus_from_dict = iob_bus.create_bus_from_dict
+create_snippet_from_dict = iob_snippet.create_snippet_from_dict
+create_iob_parameter_group_from_dict = iob_parameter_group.create_iob_parameter_group_from_dict
 
 
 class iob_core(iob_module):
@@ -183,7 +191,7 @@ class iob_core(iob_module):
         # Update current core's attributes with values from given core_dictionary
         if core_dictionary:
             # Lazy import instance to avoid circular dependecy
-            create_instance_from_dict = getattr(importlib.import_module('iob_instance'), 'create_instance_from_dict')
+            create_instance_from_dict = getattr(importlib.import_module('iob_instance'), 'iob_instance').create_instance_from_dict
             # Sanity check. These keys are only used to instantiate other user-defined/lib cores. Not iob_core directly.
             if "core" in core_dictionary or "iob_parameters" in core_dictionary:
                 fail_with_msg("The 'core' and 'iob_parameters' keys cannot be used in core dictionaries passed directly to the core constructor!")
@@ -198,8 +206,8 @@ class iob_core(iob_module):
             core_dict_with_objects["buses"] = [create_bus_from_dict(i) for i in core_dictionary.get("buses", [])]
             core_dict_with_objects["snippets"] = [create_snippet_from_dict(i) for i in core_dictionary.get("snippets", [])]
             core_dict_with_objects["subblocks"] = [create_instance_from_dict(i) for i in core_dictionary.get("subblocks", [])]
-            core_dict_with_objects["superblocks"] = [create_core_from_dict(i) for i in core_dictionary.get("superblocks", [])]
-            core_dict_with_objects["sw_modules"] = [create_core_from_dict(i) for i in core_dictionary.get("sw_modules", [])]
+            core_dict_with_objects["superblocks"] = [__class__.create_core_from_dict(i) for i in core_dictionary.get("superblocks", [])]
+            core_dict_with_objects["sw_modules"] = [__class__.create_core_from_dict(i) for i in core_dictionary.get("sw_modules", [])]
             core_dict_with_objects["iob_parameters"] = [create_iob_parameter_group_from_dict(i) for i in core_dictionary.get("iob_parameters", [])]
             update_obj_from_dict(self, core_dict_with_objects)  # valid_attributes_list=...)
 
@@ -218,7 +226,7 @@ class iob_core(iob_module):
             self.original_name = subclass_name
 
         # Try to find core's setup directory based on original name (try to find .py and .json files for it)
-        core_dir, _ = find_module_setup_dir(self.original_name, error_on_not_found=False)
+        core_dir, _ = __class__.find_module_setup_dir(self.original_name, error_on_not_found=False)
         # Auto-fill setup_dir based on found core directory.
         if not self.setup_dir and core_dir:
             self.setup_dir = core_dir
@@ -237,7 +245,7 @@ class iob_core(iob_module):
 
         # Delete existing old build directory
         if self.is_top_module:
-            clean_build_dir(self.build_dir)
+            __class__.clean_build_dir(self.build_dir)
 
         self.__create_build_dir()
 
@@ -458,221 +466,201 @@ class iob_core(iob_module):
             rules_file_path=__class__.global_clang_format_rules_filepath,
         )
 
-#
-# Non iob_core methods
-#
-
-def find_common_deep(path1, path2):
-    """Find common files (recursively) inside two given directories
-    Taken from: https://stackoverflow.com/a/51625515
-    :param str path1: Directory path 1
-    :param str path2: Directory path 2
-    """
-    return set.intersection(
-        *(
-            set(
-                os.path.relpath(os.path.join(root, file), path)
-                for root, _, files in os.walk(path)
-                for file in files
-            )
-            for path in (path1, path2)
+    @staticmethod
+    def find_module_setup_dir(core_name, error_on_not_found=True):
+        """Searches for a core's setup directory
+        param core_name: The core_name object
+        returns: The path to the setup directory
+        returns: The file extension
+        """
+        file_path = find_file(
+            iob_core.global_project_root, core_name, [".py", ".json"]
+        ) or find_file(
+            os.path.join(os.path.dirname(__file__), ".."),
+            core_name,
+            [".py", ".json"],
         )
-    )
+        if not file_path:
+            if error_on_not_found:
+                fail_with_msg(
+                    f"Python/JSON setup file of '{core_name}' core not found under path '{iob_core.global_project_root}'!",
+                    ModuleNotFoundError,
+                )
+            else:
+                return None, None
 
-def find_module_setup_dir(core_name, error_on_not_found=True):
-    """Searches for a core's setup directory
-    param core_name: The core_name object
-    returns: The path to the setup directory
-    returns: The file extension
-    """
-    file_path = find_file(
-        iob_core.global_project_root, core_name, [".py", ".json"]
-    ) or find_file(
-        os.path.join(os.path.dirname(__file__), ".."),
-        core_name,
-        [".py", ".json"],
-    )
-    if not file_path:
-        if error_on_not_found:
+        file_ext = os.path.splitext(file_path)[1]
+
+        filepath = pathlib.Path(file_path)
+        # Force core file to be contained in a folder with the same name.
+        # Skip this check if we are the top module (no top defined) or trying to setup the top module again (same name as previous defined top)
+        if filepath.parent.resolve().name != core_name and (
+            iob_core.global_top_module
+            and core_name != iob_core.global_top_module.original_name
+        ):
             fail_with_msg(
-                f"Python/JSON setup file of '{core_name}' core not found under path '{iob_core.global_project_root}'!",
-                ModuleNotFoundError,
+                f"Setup file of '{core_name}' must be contained in a folder with the same name!\n"
+                f"It should be in a path like: '{filepath.parent.resolve()}/{core_name}/{filepath.name}'.\n"
+                f"But found incorrect path:    '{filepath.resolve()}'."
             )
-        else:
-            return None, None
 
-    file_ext = os.path.splitext(file_path)[1]
+        # print("Found setup dir based on location of: " + file_path, file=sys.stderr)
+        if file_ext == ".py" or file_ext == ".json":
+            return os.path.dirname(file_path), file_ext
 
-    filepath = pathlib.Path(file_path)
-    # Force core file to be contained in a folder with the same name.
-    # Skip this check if we are the top module (no top defined) or trying to setup the top module again (same name as previous defined top)
-    if filepath.parent.resolve().name != core_name and (
-        iob_core.global_top_module
-        and core_name != iob_core.global_top_module.original_name
-    ):
-        fail_with_msg(
-            f"Setup file of '{core_name}' must be contained in a folder with the same name!\n"
-            f"It should be in a path like: '{filepath.parent.resolve()}/{core_name}/{filepath.name}'.\n"
-            f"But found incorrect path:    '{filepath.resolve()}'."
+    @staticmethod
+    def clean_build_dir(build_dir):
+        """
+            Clean and delete given build directory
+
+            Attributes:
+                build_dir (str): Path to the build directory
+        """
+        if not os.path.exists(build_dir):
+            return
+        print(
+            f"{iob_colors.INFO}Cleaning build directory: '{build_dir}'.{iob_colors.ENDC}"
+        )
+        os.system(f"make -C {build_dir} clean")
+        shutil.rmtree(build_dir)
+        print(
+            f"{iob_colors.INFO}Cleaning complete. Removed: '{build_dir}'.{iob_colors.ENDC}"
         )
 
-    # print("Found setup dir based on location of: " + file_path, file=sys.stderr)
-    if file_ext == ".py" or file_ext == ".json":
-        return os.path.dirname(file_path), file_ext
+    #
+    # Other Py2HWSW interface methods
+    #
 
-def clean_build_dir(build_dir):
-    """
-        Clean and delete given build directory
+    @staticmethod
+    def create_core_from_dict(core_dict):
+        """
+        Function to create iob_core object from dictionary attributes.
 
         Attributes:
-            build_dir (str): Path to the build directory
-    """
-    if not os.path.exists(build_dir):
-        return
-    print(
-        f"{iob_colors.INFO}Cleaning build directory: '{build_dir}'.{iob_colors.ENDC}"
-    )
-    os.system(f"make -C {build_dir} clean")
-    shutil.rmtree(build_dir)
-    print(
-        f"{iob_colors.INFO}Cleaning complete. Removed: '{build_dir}'.{iob_colors.ENDC}"
-    )
+            core_dict (dict): dictionary with values to initialize attributes of iob_core object.
+                This dictionary supports the following keys corresponding to the iob_core attributes:
 
+                # Module keys
+                - original_name -> iob_module.original_name
+                - name -> iob_module.name
+                - description -> iob_module.description
+                - reset_polarity -> iob_module.reset_polarity
+                - confs -> iob_module.confs
+                - wires -> iob_module.wires
+                - ports -> iob_module.ports
+                - buses -> iob_module.buses
+                - interfaces -> iob_module.interfaces
+                - snippets -> iob_module.snippets
+                - comb -> iob_module.comb
+                - fsm -> iob_module.fsm
+                - subblocks -> iob_module.subblocks = [create_core_from_dict(i) for i in subblocks]
+                - superblocks -> iob_module.superblocks = [create_core_from_dict(i) for i in superblocks]
+                - sw_modules -> iob_module.sw_modules = [create_core_from_dict(i) for i in sw_modules]
 
-#
-# Other Py2HWSW interface methods
-#
+                # Core keys
+                - version -> iob_core.version
+                - previous_version -> iob_core.previous_version
+                - setup_dir -> iob_core.setup_dir
+                - build_dir -> iob_core.build_dir
+                - use_netlist -> iob_core.use_netlist
+                - is_system -> iob_core.is_system
+                - board_list -> iob_core.board_list
+                - ignore_snippets -> iob_core.ignore_snippets
+                - generate_hw -> iob_core.generate_hw
+                - is_tester -> iob_core.is_tester
+                - iob_parameters -> iob_core.iob_parameters  # FIXME: Cant have two keys with the same name
+                - license -> iob_core.license
+                - doc_conf -> iob_core.doc_conf
+                - title -> iob_core.title
+                - dest_dir -> iob_core.dest_dir
 
+        Returns:
+            iob_core: iob_core object
+        """
+        return iob_core(core_dict)
 
-def create_core_from_dict(core_dict):
-    """
-    Function to create iob_core object from dictionary attributes.
+    @staticmethod
+    def core_text2dict(core_text):
+        """Convert core short notation text to dictionary.
+        Atributes:
+            core_text (str): Short notation text. See `create_core_from_text` for format.
 
-    Attributes:
-        core_dict (dict): dictionary with values to initialize attributes of iob_core object.
-            This dictionary supports the following keys corresponding to the iob_core attributes:
+        Returns:
+            dict: Dictionary with core attributes.
+        """
+        core_flags = [
+            # iob_module attributes
+            "original_name",
+            "name",
+            ['-d', {'dest': 'descr'}],
+            ['--rst_pol', {'dest': 'rst_policy'}],
+            ['--conf', {'dest': 'confs', 'action': 'append'}],
+            ['--port', {'dest': 'ports', 'action': 'append'}],
+            ['--bus', {'dest': 'buses', 'action': 'append'}],
+            ['--snippet', {'dest': 'snippets', 'action': 'append'}],
+            ['--comb', {'dest': 'comb'}],
+            ['--fsm', {'dest': 'fsm'}],
+            ['--subblock', {'dest': 'subblocks', 'action': 'append'}],
+            ['--superblock', {'dest': 'superblocks', 'action': 'append'}],
+            ['--sw_module', {'dest': 'sw_modules', 'action': 'append'}],
+            # iob_instance attributes
+            ['--inst_name', {'dest': 'instance_name'}],
+            ['--inst_d', {'dest': 'instance_description'}],
+            ['-c', {'dest': 'connect', 'action': 'append'}],  # port:ext format
+            ['--param', {'dest': 'parameters', 'action': 'append'}],  # PARAM:VALUE format
+            ['--no-instantiate', {'dest': 'instantiate', 'action': 'store_false'}],
+            ['--dest_dir', {'dest': 'dest_dir'}],
+            # iob_core attributes
+            ['-v', {'dest': 'version'}],
+            ['--prev_v', {'dest': 'previous_version'}],
+            ['--setup_dir', {'dest': 'setup_dir'}],
+            ['--build_dir', {'dest': 'build_dir'}],
+            ['--use_netlist', {'dest': 'use_netlist', 'action': 'store_true'}],
+            ['--system', {'dest': 'is_system', 'action': 'store_true'}],
+            ['--board', {'dest': 'board_list', 'action': 'append'}],
+            ['--ignore_snippet', {'dest': 'ignore_snippets', 'action': 'append'}],
+            ['--gen_hw', {'dest': 'generate_hw', 'action': 'store_true'}],
+            ['--parent', {'dest': 'parent'}],
+            ['--tester', {'dest': 'is_tester', 'action': 'store_true'}],
+            ['--iob_param', {'dest': 'iob_parameters', 'action': 'append'}],
+            ['--lic', {'dest': 'license'}],
+            ['--doc_conf', {'dest': 'doc_conf'}],
+            ['--title', {'dest': 'title'}],
+        ]
+        core_dict = parse_short_notation_text(core_text, core_flags)
+        # TODO: process core_dict:
+        #   - confs, ports, buses, snippets, comb, fsm,
+        #   - subblocks, superblocks, sw_modules
+        #   - connect -> portmap_connections, parameters, ignore_snippets?
+        #   - parent?, iob_parameters
+        return core_dict
 
-            # Module keys
-            - original_name -> iob_module.original_name
-            - name -> iob_module.name
-            - description -> iob_module.description
-            - reset_polarity -> iob_module.reset_polarity
-            - confs -> iob_module.confs
-            - wires -> iob_module.wires
-            - ports -> iob_module.ports
-            - buses -> iob_module.buses
-            - interfaces -> iob_module.interfaces
-            - snippets -> iob_module.snippets
-            - comb -> iob_module.comb
-            - fsm -> iob_module.fsm
-            - subblocks -> iob_module.subblocks = [create_core_from_dict(i) for i in subblocks]
-            - superblocks -> iob_module.superblocks = [create_core_from_dict(i) for i in superblocks]
-            - sw_modules -> iob_module.sw_modules = [create_core_from_dict(i) for i in sw_modules]
+    @staticmethod
+    def create_core_from_text(core_text):
+        """
+        Function to create iob_core object from short notation text.
 
-            # Core keys
-            - version -> iob_core.version
-            - previous_version -> iob_core.previous_version
-            - setup_dir -> iob_core.setup_dir
-            - build_dir -> iob_core.build_dir
-            - use_netlist -> iob_core.use_netlist
-            - is_system -> iob_core.is_system
-            - board_list -> iob_core.board_list
-            - ignore_snippets -> iob_core.ignore_snippets
-            - generate_hw -> iob_core.generate_hw
-            - is_tester -> iob_core.is_tester
-            - iob_parameters -> iob_core.iob_parameters  # FIXME: Cant have two keys with the same name
-            - license -> iob_core.license
-            - doc_conf -> iob_core.doc_conf
-            - title -> iob_core.title
-            - dest_dir -> iob_core.dest_dir
+        Attributes:
+            core_text (str): Short notation text. Object attributes are specified using the following format:
+                # Notation specific to modules
+                original_name
 
-    Returns:
-        iob_core: iob_core object
-    """
-    return iob_core(core_dict)
+                # Notation specific to cores
+                # TODO
 
+                # Below are parameters specific to the 'iob_csrs' module. They should probably not belong in the Py2HWSW code
+                [--no_autoaddr]
+                [--rw_overlap]
+                [--csr_if csr_if]
+                    [--csr-group csr_group_name]
+                        [-r reg_name:n_bits]
+                            [-t type] [-m mode] [--rst_val rst_val] [--addr addr] [--log2n_items log2n_items]
 
-def core_text2dict(core_text):
-    """Convert core short notation text to dictionary.
-    Atributes:
-        core_text (str): Short notation text. See `create_core_from_text` for format.
+        Returns:
+            iob_core: iob_core object
+        """
+        return __class__.create_core_from_dict(__class__.core_text2dict(core_text))
 
-    Returns:
-        dict: Dictionary with core attributes.
-    """
-    core_flags = [
-        # iob_module attributes
-        "original_name",
-        "name",
-        ['-d', {'dest': 'descr'}],
-        ['--rst_pol', {'dest': 'rst_policy'}],
-        ['--conf', {'dest': 'confs', 'action': 'append'}],
-        ['--port', {'dest': 'ports', 'action': 'append'}],
-        ['--bus', {'dest': 'buses', 'action': 'append'}],
-        ['--snippet', {'dest': 'snippets', 'action': 'append'}],
-        ['--comb', {'dest': 'comb'}],
-        ['--fsm', {'dest': 'fsm'}],
-        ['--subblock', {'dest': 'subblocks', 'action': 'append'}],
-        ['--superblock', {'dest': 'superblocks', 'action': 'append'}],
-        ['--sw_module', {'dest': 'sw_modules', 'action': 'append'}],
-        # iob_instance attributes
-        ['--inst_name', {'dest': 'instance_name'}],
-        ['--inst_d', {'dest': 'instance_description'}],
-        ['-c', {'dest': 'connect', 'action': 'append'}],  # port:ext format
-        ['--param', {'dest': 'parameters', 'action': 'append'}],  # PARAM:VALUE format
-        ['--no-instantiate', {'dest': 'instantiate', 'action': 'store_false'}],
-        ['--dest_dir', {'dest': 'dest_dir'}],
-        # iob_core attributes
-        ['-v', {'dest': 'version'}],
-        ['--prev_v', {'dest': 'previous_version'}],
-        ['--setup_dir', {'dest': 'setup_dir'}],
-        ['--build_dir', {'dest': 'build_dir'}],
-        ['--use_netlist', {'dest': 'use_netlist', 'action': 'store_true'}],
-        ['--system', {'dest': 'is_system', 'action': 'store_true'}],
-        ['--board', {'dest': 'board_list', 'action': 'append'}],
-        ['--ignore_snippet', {'dest': 'ignore_snippets', 'action': 'append'}],
-        ['--gen_hw', {'dest': 'generate_hw', 'action': 'store_true'}],
-        ['--parent', {'dest': 'parent'}],
-        ['--tester', {'dest': 'is_tester', 'action': 'store_true'}],
-        ['--iob_param', {'dest': 'iob_parameters', 'action': 'append'}],
-        ['--lic', {'dest': 'license'}],
-        ['--doc_conf', {'dest': 'doc_conf'}],
-        ['--title', {'dest': 'title'}],
-    ]
-    core_dict = parse_short_notation_text(core_text, core_flags)
-    # TODO: process core_dict:
-    #   - confs, ports, buses, snippets, comb, fsm,
-    #   - subblocks, superblocks, sw_modules
-    #   - connect -> portmap_connections, parameters, ignore_snippets?
-    #   - parent?, iob_parameters
-    return core_dict
-
-
-def create_core_from_text(core_text):
-    """
-    Function to create iob_core object from short notation text.
-
-    Attributes:
-        core_text (str): Short notation text. Object attributes are specified using the following format:
-            # Notation specific to modules
-            original_name
-
-            # Notation specific to cores
-            # TODO
-
-            # Below are parameters specific to the 'iob_csrs' module. They should probably not belong in the Py2HWSW code
-            [--no_autoaddr]
-            [--rw_overlap]
-            [--csr_if csr_if]
-                [--csr-group csr_group_name]
-                    [-r reg_name:n_bits]
-                        [-t type] [-m mode] [--rst_val rst_val] [--addr addr] [--log2n_items log2n_items]
-
-    Returns:
-        iob_core: iob_core object
-    """
-    return create_core_from_dict(core_text2dict(core_text))
-
-
-def get_global_wires_list():
-    return iob_core.global_wires
+    @staticmethod
+    def get_global_wires_list():
+        return iob_core.global_wires

--- a/py2hwsw/src/iob_core.py
+++ b/py2hwsw/src/iob_core.py
@@ -63,6 +63,15 @@ class iob_core(iob_module):
     """
     Generic class to describe how to generate a base IOb IP core.
 
+    This class may be instantiated using 3 different interfaces:
+    - Object interface:          by calling the `__init__()` constructor.
+    - Dictionary/JSON interface: by calling the `create_core_from_dict()` method.
+    - Short Notation interface:  by calling the `create_core_from_text()` method.
+
+    To see the arguments supported by the constructor that initializes this class, refer to the `__init__()` method of this class.
+    To see the keys supported by the dictionary that initializes this class, refer to the `create_core_from_dict()` method of this class.
+    To see the syntax supported by the short notation that initializes this class, refer to the `create_core_from_text()` method of this class.
+
     Attributes:
         # Module attributes
         original_name (str): Original name of the module. Usually auto-filled by Py2HWSW.
@@ -129,6 +138,7 @@ class iob_core(iob_module):
 
         Attributes:
             core_dictionary (dict): Optional dictionary to initialize core attributes.
+                                    The format of this dictionary is the same as the dictionary received by the `create_core_from_dict` method.
         """
 
         # Inherit attributes from superclasses
@@ -545,17 +555,17 @@ class iob_core(iob_module):
                 - name -> iob_module.name
                 - description -> iob_module.description
                 - reset_polarity -> iob_module.reset_polarity
-                - confs -> iob_module.confs
-                - wires -> iob_module.wires
-                - ports -> iob_module.ports
-                - buses -> iob_module.buses
-                - interfaces -> iob_module.interfaces
-                - snippets -> iob_module.snippets
-                - comb -> iob_module.comb
-                - fsm -> iob_module.fsm
-                - subblocks -> iob_module.subblocks = [create_core_from_dict(i) for i in subblocks]
-                - superblocks -> iob_module.superblocks = [create_core_from_dict(i) for i in superblocks]
-                - sw_modules -> iob_module.sw_modules = [create_core_from_dict(i) for i in sw_modules]
+                - confs -> iob_module.confs = [iob_conf.create_conf_from_dict(i) for i in confs]
+                - wires -> iob_module.wires = [iob_wire.create_wire_from_dict(i) for i in wires]
+                - ports -> iob_module.ports = [iob_port.create_port_from_dict(i) for i in ports]
+                - buses -> iob_module.buses = [iob_bus.create_bus_from_dict(i) for i in buses]
+                - interfaces -> iob_module.interfaces = [iob_interface.create_interface_from_dict(i) for i in interfaces]
+                - snippets -> iob_module.snippets = [iob_snippet.create_snippet_from_dict(i) for i in snippets]
+                - comb -> iob_module.comb = create_comb_from_dict(comb)
+                - fsm -> iob_module.fsm = create_fsm_from_dict(fsm)
+                - subblocks -> iob_module.subblocks = [iob_instance.create_instance_from_dict(i) for i in subblocks]
+                - superblocks -> iob_module.superblocks = [iob_core.create_core_from_dict(i) for i in superblocks]
+                - sw_modules -> iob_module.sw_modules = [iob_core.create_core_from_dict(i) for i in sw_modules]
 
                 # Core keys
                 - version -> iob_core.version
@@ -573,6 +583,10 @@ class iob_core(iob_module):
                 - doc_conf -> iob_core.doc_conf
                 - title -> iob_core.title
                 - dest_dir -> iob_core.dest_dir
+
+                Some keys (like confs) may contain (sub-)dictionaries as values.
+                Refer to the corresponding `<class_name>.create_*_from_dict()` methods for info about the format and supported keys of these dictionaries.
+                For example, type `help(iob_conf.create_conf_from_dict)` to view the keys supported by the dictionary that initializes the iob_conf object.
 
         Returns:
             iob_core: iob_core object

--- a/py2hwsw/src/iob_core.py
+++ b/py2hwsw/src/iob_core.py
@@ -51,13 +51,6 @@ from iob_snippet import iob_snippet
 from iob_license import iob_license
 from iob_parameter import iob_parameter_group
 
-create_conf_from_dict = iob_conf.create_conf_from_dict
-create_wire_from_dict = iob_wire.create_wire_from_dict
-create_port_from_dict = iob_port.create_port_from_dict
-create_bus_from_dict = iob_bus.create_bus_from_dict
-create_snippet_from_dict = iob_snippet.create_snippet_from_dict
-create_iob_parameter_group_from_dict = iob_parameter_group.create_iob_parameter_group_from_dict
-
 
 class iob_core(iob_module):
     """
@@ -65,12 +58,12 @@ class iob_core(iob_module):
 
     This class may be instantiated using 3 different interfaces:
     - Object interface:          by calling the `__init__()` constructor.
-    - Dictionary/JSON interface: by calling the `create_core_from_dict()` method.
-    - Short Notation interface:  by calling the `create_core_from_text()` method.
+    - Dictionary/JSON interface: by calling the `create_from_dict()` method.
+    - Short Notation interface:  by calling the `create_from_text()` method.
 
     To see the arguments supported by the constructor that initializes this class, refer to the `__init__()` method of this class.
-    To see the keys supported by the dictionary that initializes this class, refer to the `create_core_from_dict()` method of this class.
-    To see the syntax supported by the short notation that initializes this class, refer to the `create_core_from_text()` method of this class.
+    To see the keys supported by the dictionary that initializes this class, refer to the `create_from_dict()` method of this class.
+    To see the syntax supported by the short notation that initializes this class, refer to the `create_from_text()` method of this class.
 
     Attributes:
         # Module attributes
@@ -138,7 +131,7 @@ class iob_core(iob_module):
 
         Attributes:
             core_dictionary (dict): Optional dictionary to initialize core attributes.
-                                    The format of this dictionary is the same as the dictionary received by the `create_core_from_dict` method.
+                                    The format of this dictionary is the same as the dictionary received by the `create_from_dict` method.
         """
 
         # Inherit attributes from superclasses
@@ -201,7 +194,7 @@ class iob_core(iob_module):
         # Update current core's attributes with values from given core_dictionary
         if core_dictionary:
             # Lazy import instance to avoid circular dependecy
-            create_instance_from_dict = getattr(importlib.import_module('iob_instance'), 'iob_instance').create_instance_from_dict
+            iob_instance = getattr(importlib.import_module('iob_instance'), 'iob_instance')
             # Sanity check. These keys are only used to instantiate other user-defined/lib cores. Not iob_core directly.
             if "core" in core_dictionary or "iob_parameters" in core_dictionary:
                 fail_with_msg("The 'core' and 'iob_parameters' keys cannot be used in core dictionaries passed directly to the core constructor!")
@@ -210,15 +203,15 @@ class iob_core(iob_module):
             for c in core_dictionary.get("confs", []):
                 if "type" in c:
                     breakpoint()
-            core_dict_with_objects["confs"] = [create_conf_from_dict(i) for i in core_dictionary.get("confs", [])]
-            core_dict_with_objects["ports"] = [create_port_from_dict(i) for i in core_dictionary.get("ports", [])]
-            core_dict_with_objects["wires"] = [create_wire_from_dict(i) for i in core_dictionary.get("wires", [])]
-            core_dict_with_objects["buses"] = [create_bus_from_dict(i) for i in core_dictionary.get("buses", [])]
-            core_dict_with_objects["snippets"] = [create_snippet_from_dict(i) for i in core_dictionary.get("snippets", [])]
-            core_dict_with_objects["subblocks"] = [create_instance_from_dict(i) for i in core_dictionary.get("subblocks", [])]
-            core_dict_with_objects["superblocks"] = [__class__.create_core_from_dict(i) for i in core_dictionary.get("superblocks", [])]
-            core_dict_with_objects["sw_modules"] = [__class__.create_core_from_dict(i) for i in core_dictionary.get("sw_modules", [])]
-            core_dict_with_objects["iob_parameters"] = [create_iob_parameter_group_from_dict(i) for i in core_dictionary.get("iob_parameters", [])]
+            core_dict_with_objects["confs"] = [iob_conf.create_from_dict(i) for i in core_dictionary.get("confs", [])]
+            core_dict_with_objects["ports"] = [iob_port.create_from_dict(i) for i in core_dictionary.get("ports", [])]
+            core_dict_with_objects["wires"] = [iob_wire.create_from_dict(i) for i in core_dictionary.get("wires", [])]
+            core_dict_with_objects["buses"] = [iob_bus.create_from_dict(i) for i in core_dictionary.get("buses", [])]
+            core_dict_with_objects["snippets"] = [iob_snippet.create_from_dict(i) for i in core_dictionary.get("snippets", [])]
+            core_dict_with_objects["subblocks"] = [iob_instance.create_from_dict(i) for i in core_dictionary.get("subblocks", [])]
+            core_dict_with_objects["superblocks"] = [__class__.create_from_dict(i) for i in core_dictionary.get("superblocks", [])]
+            core_dict_with_objects["sw_modules"] = [__class__.create_from_dict(i) for i in core_dictionary.get("sw_modules", [])]
+            core_dict_with_objects["iob_parameters"] = [iob_parameter_group.create_from_dict(i) for i in core_dictionary.get("iob_parameters", [])]
             update_obj_from_dict(self, core_dict_with_objects)  # valid_attributes_list=...)
 
         # Set global build directory
@@ -542,7 +535,7 @@ class iob_core(iob_module):
     #
 
     @staticmethod
-    def create_core_from_dict(core_dict):
+    def create_from_dict(core_dict):
         """
         Function to create iob_core object from dictionary attributes.
 
@@ -555,17 +548,17 @@ class iob_core(iob_module):
                 - name -> iob_module.name
                 - description -> iob_module.description
                 - reset_polarity -> iob_module.reset_polarity
-                - confs -> iob_module.confs = [iob_conf.create_conf_from_dict(i) for i in confs]
-                - wires -> iob_module.wires = [iob_wire.create_wire_from_dict(i) for i in wires]
-                - ports -> iob_module.ports = [iob_port.create_port_from_dict(i) for i in ports]
-                - buses -> iob_module.buses = [iob_bus.create_bus_from_dict(i) for i in buses]
-                - interfaces -> iob_module.interfaces = [iob_interface.create_interface_from_dict(i) for i in interfaces]
-                - snippets -> iob_module.snippets = [iob_snippet.create_snippet_from_dict(i) for i in snippets]
-                - comb -> iob_module.comb = create_comb_from_dict(comb)
-                - fsm -> iob_module.fsm = create_fsm_from_dict(fsm)
-                - subblocks -> iob_module.subblocks = [iob_instance.create_instance_from_dict(i) for i in subblocks]
-                - superblocks -> iob_module.superblocks = [iob_core.create_core_from_dict(i) for i in superblocks]
-                - sw_modules -> iob_module.sw_modules = [iob_core.create_core_from_dict(i) for i in sw_modules]
+                - confs -> iob_module.confs = [iob_conf.create_from_dict(i) for i in confs]
+                - wires -> iob_module.wires = [iob_wire.create_from_dict(i) for i in wires]
+                - ports -> iob_module.ports = [iob_port.create_from_dict(i) for i in ports]
+                - buses -> iob_module.buses = [iob_bus.create_from_dict(i) for i in buses]
+                - interfaces -> iob_module.interfaces = [iob_interface.create_from_dict(i) for i in interfaces]
+                - snippets -> iob_module.snippets = [iob_snippet.create_from_dict(i) for i in snippets]
+                - comb -> iob_module.comb = iob_comb.create_from_dict(comb)
+                - fsm -> iob_module.fsm = iob_fsm.create_from_dict(fsm)
+                - subblocks -> iob_module.subblocks = [iob_instance.create_from_dict(i) for i in subblocks]
+                - superblocks -> iob_module.superblocks = [iob_core.create_from_dict(i) for i in superblocks]
+                - sw_modules -> iob_module.sw_modules = [iob_core.create_from_dict(i) for i in sw_modules]
 
                 # Core keys
                 - version -> iob_core.version
@@ -585,8 +578,8 @@ class iob_core(iob_module):
                 - dest_dir -> iob_core.dest_dir
 
                 Some keys (like confs) may contain (sub-)dictionaries as values.
-                Refer to the corresponding `<class_name>.create_*_from_dict()` methods for info about the format and supported keys of these dictionaries.
-                For example, type `help(iob_conf.create_conf_from_dict)` to view the keys supported by the dictionary that initializes the iob_conf object.
+                Refer to the corresponding `<class_name>.create_from_dict()` methods for info about the format and supported keys of these dictionaries.
+                For example, type `help(iob_conf.create_from_dict)` to view the keys supported by the dictionary that initializes the iob_conf object.
 
         Returns:
             iob_core: iob_core object
@@ -597,7 +590,7 @@ class iob_core(iob_module):
     def core_text2dict(core_text):
         """Convert core short notation text to dictionary.
         Atributes:
-            core_text (str): Short notation text. See `create_core_from_text` for format.
+            core_text (str): Short notation text. See `create_from_text` for format.
 
         Returns:
             dict: Dictionary with core attributes.
@@ -650,7 +643,7 @@ class iob_core(iob_module):
         return core_dict
 
     @staticmethod
-    def create_core_from_text(core_text):
+    def create_from_text(core_text):
         """
         Function to create iob_core object from short notation text.
 
@@ -673,7 +666,7 @@ class iob_core(iob_module):
         Returns:
             iob_core: iob_core object
         """
-        return __class__.create_core_from_dict(__class__.core_text2dict(core_text))
+        return __class__.create_from_dict(__class__.core_text2dict(core_text))
 
     @staticmethod
     def get_global_wires_list():

--- a/py2hwsw/src/iob_fsm.py
+++ b/py2hwsw/src/iob_fsm.py
@@ -132,7 +132,7 @@ end
     #
 
     @staticmethod
-    def create_fsm_from_dict(fsm_dict):
+    def create_from_dict(fsm_dict):
         """
         Function to create iob_fsm object from dictionary attributes.
 
@@ -152,7 +152,7 @@ end
     def fsm_text2dict(fsm_text):
         """Convert fsm short notation text to dictionary.
         Atributes:
-            fsm_text (str): Short notation text. See `create_fsm_from_text` for format.
+            fsm_text (str): Short notation text. See `create_from_text` for format.
 
         Returns:
             dict: Dictionary with fsm attributes.
@@ -165,7 +165,7 @@ end
         return parse_short_notation_text(fsm_text, fsm_flags)
 
     @staticmethod
-    def create_fsm_from_text(fsm_text):
+    def create_from_text(fsm_text):
         """
         Function to create iob_fsm object from short notation text.
 
@@ -193,4 +193,4 @@ end
         Returns:
             iob_fsm: iob_fsm object
         """
-        return __class__.create_fsm_from_dict(__class__.fsm_text2dict(fsm_text))
+        return __class__.create_from_dict(__class__.fsm_text2dict(fsm_text))

--- a/py2hwsw/src/iob_fsm.py
+++ b/py2hwsw/src/iob_fsm.py
@@ -88,110 +88,109 @@ always @* begin
 end
 """
 
+    @staticmethod
+    def create_fsm(core, *args, **kwargs):
+        """Create a Verilog finite state machine to insert in a given core."""
+        if core.comb is not None:
+            raise ValueError(
+                "Combinational logic is mutually exclusive with FSMs. Create separate submodules for each."
+            )
 
-def create_fsm(core, *args, **kwargs):
-    """Create a Verilog finite state machine to insert in a given core."""
-    if core.comb is not None:
-        raise ValueError(
-            "Combinational logic is mutually exclusive with FSMs. Create separate submodules for each."
+        core.set_default_attribute("fsm", None)
+
+        default_assignments = kwargs.get("default_assignments", "")
+        kind = kwargs.get("type", "prog")
+        state_descriptions = kwargs.get("state_descriptions", "")
+
+        assert_attributes(
+            iob_fsm,
+            kwargs,
+            error_msg=f"Invalid {kwargs.get('name', '')} fsm attribute '[arg]'!",
+        )
+        fsm = iob_fsm(
+            kind=kind,
+            default_assignments=default_assignments,
+            state_descriptions=state_descriptions,
         )
 
-    core.set_default_attribute("fsm", None)
+        # Check if the FSM bus is already created, if not create it
+        if not any(bus.name == fsm.state_reg_name for bus in core.buses):
+            core.create_bus(
+                name=fsm.state_reg_name,
+                descr="FSM state",
+                wires=[{"name": fsm.state_reg_name, "width": fsm.state_reg_width}],
+            )
 
-    default_assignments = kwargs.get("default_assignments", "")
-    kind = kwargs.get("type", "prog")
-    state_descriptions = kwargs.get("state_descriptions", "")
+        fsm.set_needed_reg(core)
 
-    assert_attributes(
-        iob_fsm,
-        kwargs,
-        error_msg=f"Invalid {kwargs.get('name', '')} fsm attribute '[arg]'!",
-    )
-    fsm = iob_fsm(
-        kind=kind,
-        default_assignments=default_assignments,
-        state_descriptions=state_descriptions,
-    )
+        fsm.infer_registers(core)
 
-    # Check if the FSM bus is already created, if not create it
-    if not any(bus.name == fsm.state_reg_name for bus in core.buses):
-        core.create_bus(
-            name=fsm.state_reg_name,
-            descr="FSM state",
-            wires=[{"name": fsm.state_reg_name, "width": fsm.state_reg_width}],
-        )
+        core.fsm = fsm
 
-    fsm.set_needed_reg(core)
+    #
+    # Other Py2HWSW interface methods
+    #
 
-    fsm.infer_registers(core)
+    @staticmethod
+    def create_fsm_from_dict(fsm_dict):
+        """
+        Function to create iob_fsm object from dictionary attributes.
 
-    core.fsm = fsm
+        Attributes:
+            fsm_dict (dict): dictionary with values to initialize attributes of iob_fsm object.
+                This dictionary supports the following keys corresponding to the iob_fsm attributes:
+                - type -> iob_fsm.kind
+                - default_assignments -> iob_fsm.default_assignments
+                - state_descriptions -> iob_fsm.state_descriptions
 
+        Returns:
+            iob_fsm: iob_fsm object
+        """
+        return iob_fsm(**fsm_dict)
 
-#
-# Other Py2HWSW interface methods
-#
+    @staticmethod
+    def fsm_text2dict(fsm_text):
+        """Convert fsm short notation text to dictionary.
+        Atributes:
+            fsm_text (str): Short notation text. See `create_fsm_from_text` for format.
 
+        Returns:
+            dict: Dictionary with fsm attributes.
+        """
+        fsm_flags = [
+            ["-t", {"dest": "kind", "choices": ["prog", "fsm"]}],
+            ["-d", {"dest": "default_assignments"}],
+            ["-s", {"dest": "state_descriptions"}],
+        ]
+        return parse_short_notation_text(fsm_text, fsm_flags)
 
-def create_fsm_from_dict(fsm_dict):
-    """
-    Function to create iob_fsm object from dictionary attributes.
+    @staticmethod
+    def create_fsm_from_text(fsm_text):
+        """
+        Function to create iob_fsm object from short notation text.
 
-    Attributes:
-        fsm_dict (dict): dictionary with values to initialize attributes of iob_fsm object.
-            This dictionary supports the following keys corresponding to the iob_fsm attributes:
-            - type -> iob_fsm.kind
-            - default_assignments -> iob_fsm.default_assignments
-            - state_descriptions -> iob_fsm.state_descriptions
+        Attributes:
+            fsm_text (str): Short notation text. Object attributes are specified using the following format:
+                [-t kind] [-d default_assignments] [-s state_descriptions]
+                Example:
+                    -t fsm
+                    -d 'a_o = 10;'
+                    -s
+                    {{
+                        A: a_o = 0;
+                        B: a_o = 1;
+                        a_o = 2;
+                        if(a_o == 0)
+                        begin
+                            pcnt_nxt = A;
+                        end
+                        else
+                        begin
+                            pcnt_nxt = B;
+                        end
+                    }}
 
-    Returns:
-        iob_fsm: iob_fsm object
-    """
-    return iob_fsm(**fsm_dict)
-
-
-def fsm_text2dict(fsm_text):
-    """Convert fsm short notation text to dictionary.
-    Atributes:
-        fsm_text (str): Short notation text. See `create_fsm_from_text` for format.
-
-    Returns:
-        dict: Dictionary with fsm attributes.
-    """
-    fsm_flags = [
-        ["-t", {"dest": "kind", "choices": ["prog", "fsm"]}],
-        ["-d", {"dest": "default_assignments"}],
-        ["-s", {"dest": "state_descriptions"}],
-    ]
-    return parse_short_notation_text(fsm_text, fsm_flags)
-
-
-def create_fsm_from_text(fsm_text):
-    """
-    Function to create iob_fsm object from short notation text.
-
-    Attributes:
-        fsm_text (str): Short notation text. Object attributes are specified using the following format:
-            [-t kind] [-d default_assignments] [-s state_descriptions]
-            Example:
-                -t fsm
-                -d 'a_o = 10;'
-                -s
-                {{
-                    A: a_o = 0;
-                    B: a_o = 1;
-                    a_o = 2;
-                    if(a_o == 0)
-                    begin
-                        pcnt_nxt = A;
-                    end
-                    else
-                    begin
-                        pcnt_nxt = B;
-                    end
-                }}
-
-    Returns:
-        iob_fsm: iob_fsm object
-    """
-    return create_fsm_from_dict(fsm_text2dict(fsm_text))
+        Returns:
+            iob_fsm: iob_fsm object
+        """
+        return __class__.create_fsm_from_dict(__class__.fsm_text2dict(fsm_text))

--- a/py2hwsw/src/iob_globals.py
+++ b/py2hwsw/src/iob_globals.py
@@ -6,10 +6,36 @@ from iob_base import fail_with_msg
 
 
 class iob_globals:
+    """
+    A singleton class for managing project-wide global variables.
+
+    This class ensures that only one instance exists throughout the project.
+    It allows for the creation and management of global variables in a controlled manner.
+
+    Attributes:
+        None (attributes are set dynamically)
+
+    Notes:
+        - Existing attributes cannot be modified once set.
+        - New attributes can be added, but not changed if they already exist.
+    """
+
     _instance = None
     _is_set = False
 
     def __new__(cls, **kwargs):
+        """
+        Creates or returns the singleton instance of `iob_globals`.
+
+        If the instance already exists and new attributes are provided,
+        only new attributes are added, ignoring existing ones.
+
+        Args:
+            **kwargs: Key-value pairs of attributes to set.
+
+        Returns:
+            The singleton instance of `iob_globals`.
+        """
         if cls._is_set:
             # Only set new attributes — ignore existing ones
             for k, v in kwargs.items():
@@ -25,6 +51,16 @@ class iob_globals:
         return cls._instance
 
     def __setattr__(self, key, value):
+        """
+        Sets a new attribute on the instance.
+
+        Args:
+            key (str): The name of the attribute to set.
+            value: The value of the attribute to set.
+
+        Raises:
+            AttributeError: If the attribute already exists.
+        """
         if hasattr(self, key):
             fail_with_msg(
                 f"Cannot modify existing attribute '{key}'.",
@@ -32,13 +68,19 @@ class iob_globals:
             )
         super().__setattr__(key, value)
 
+    @staticmethod
+    def create_globals(core, attr_name, value):
+        """
+        Creates a singleton instance of `iob_globals` with the given attribute.
 
-def create_globals(core, attr_name, value):
-    """
-    Create a singleton instance of iob_globals with the given attributes.
-    If the instance already exists, it will not be modified.
-    """
-    if core.is_top_module:
-        core.set_default_attribute(
-            attr_name, getattr(iob_globals(**{attr_name: value}), attr_name)
-        )
+        If the instance already exists, it will not be modified.
+
+        Args:
+            core: The core object.
+            attr_name (str): The name of the attribute to set.
+            value: The value of the attribute to set.
+        """
+        if core.is_top_module:
+            core.set_default_attribute(
+                attr_name, getattr(iob_globals(**{attr_name: value}), attr_name)
+            )

--- a/py2hwsw/src/iob_instance.py
+++ b/py2hwsw/src/iob_instance.py
@@ -22,9 +22,7 @@ from iob_wire import iob_wire
 from iob_core import iob_core
 
 get_portmap_port = iob_portmap.get_portmap_port
-create_portmap_from_dict = iob_portmap.create_portmap_from_dict
 remove_direction_suffixes = iob_wire.remove_wire_direction_suffixes
-create_core_from_dict = iob_core.create_core_from_dict
 find_module_setup_dir = iob_core.find_module_setup_dir
 
 
@@ -362,7 +360,7 @@ class iob_instance(iob_base):
 
         elif file_ext == ".json":
             debug_print(f"Loading {block_name}.json", 1)
-            block_obj = create_core_from_dict(
+            block_obj = iob_core.create_from_dict(
                 json.load(open(os.path.join(block_dir, f"{block_name}.json")))
             )
 
@@ -382,7 +380,7 @@ class iob_instance(iob_base):
     #
 
     @staticmethod
-    def create_instance_from_dict(instance_dict):
+    def create_from_dict(instance_dict):
         """
         Function to create iob_instance object from dictionary attributes.
 
@@ -392,14 +390,14 @@ class iob_instance(iob_base):
                 - core -> iob_instance.core
                 - name -> iob_instance.name
                 - description -> iob_instance.description
-                - portmap_connections -> iob_instance.portmap_connections = create_portmap_from_dict(portmap_connections)
+                - portmap_connections -> iob_instance.portmap_connections = iob_portmap.create_from_dict(portmap_connections)
                 - parameters -> iob_instance.parameters
                 - instantiate -> iob_instance.instantiate
                 # Non-attribute instance keys
                 - core (str): Optional. The name of the core to instantiate. Will search for <core>.py or <core>.json files.
                               If this key is set, all other keys will be ignored! (Except 'iob_parameters' key).
                               If <core>.py is found, it must contain a class called <core> that extends iob_core. This class will be used to instantiate the core.
-                              If <core>.json is found, its contents will be read and parsed by the create_core_from_dict(<json_contents>) function.
+                              If <core>.json is found, its contents will be read and parsed by the iob_core.create_from_dict(<json_contents>) function.
                 - iob_parameters (dict): Optional. Dictionary of iob parameters to pass to the instantiated core.
                                             This key should be used in conjunction with the 'core' key.
                                             Elements from this dictionary will be passed as **kwargs to the instantiated core's constructor.
@@ -420,7 +418,7 @@ class iob_instance(iob_base):
 
         # instantiate_block(instance_dict["core"], instance_dict.get("iob_parameters", {}), instance_dict)
 
-        # instance_dict_with_objects["portmap_connections"] = create_portmap_from_dict(instance_dictionary.get("portmap_connections", {}))
+        # instance_dict_with_objects["portmap_connections"] = iob_portmap.create_from_dict(instance_dictionary.get("portmap_connections", {}))
         # return iob_instance(**instance_dict)
 
         # remove non-attribute keys
@@ -428,12 +426,12 @@ class iob_instance(iob_base):
         iob_parameters = instance_dict.pop("iob_parameters", {})
         portmap_connections = instance_dict.pop("portmap_connections", {})
         instance_dict.update(
-            {"portmap_connections": create_portmap_from_dict(portmap_connections)}
+            {"portmap_connections": iob_portmap.create_from_dict(portmap_connections)}
         )
         return __class__.instantiate_block(core, iob_parameters, instance_dict)
 
     @staticmethod
-    def create_instance_from_text(instance_text):
+    def create_from_text(instance_text):
         """
         Function to create iob_instance object from short notation text.
 

--- a/py2hwsw/src/iob_interface.py
+++ b/py2hwsw/src/iob_interface.py
@@ -562,7 +562,7 @@ class iob_interface:
     #
 
     @staticmethod
-    def create_interface_from_dict(interface_dict):
+    def create_from_dict(interface_dict):
         """
         Function to create interface object from dictionary attributes.
 
@@ -584,7 +584,7 @@ class iob_interface:
     def interface_text2dict(interface_text):
         """Convert interface short notation text to dictionary.
         Atributes:
-            interface_text (str): Short notation text. See `create_interface_from_text` for format.
+            interface_text (str): Short notation text. See `create_from_text` for format.
 
         Returns:
             dict: Dictionary with interface attributes.
@@ -612,7 +612,7 @@ class iob_interface:
         return interface_dict
 
     @staticmethod
-    def create_interface_from_text(interface_text):
+    def create_from_text(interface_text):
         """
         Function to create interface object from short notation text.
 
@@ -629,7 +629,7 @@ class iob_interface:
         Returns:
             interface: interface object
         """
-        return __class__.create_interface_from_dict(__class__.interface_text2dict(interface_text))
+        return __class__.create_from_dict(__class__.interface_text2dict(interface_text))
 
 
 #

--- a/py2hwsw/src/iob_interface.py
+++ b/py2hwsw/src/iob_interface.py
@@ -557,6 +557,80 @@ class iob_interface:
         print(f"ERROR: get_interface_details: unknown interface {if_name}.")
         exit(1)
 
+    #
+    # Other Py2HWSW interface methods
+    #
+
+    @staticmethod
+    def create_interface_from_dict(interface_dict):
+        """
+        Function to create interface object from dictionary attributes.
+
+        Attributes:
+            interface_dict (dict): dictionary with values to initialize attributes of interface object.
+                This dictionary supports the following keys corresponding to the interface attributes:
+                - if_direction        -> interface.if_direction
+                - prefix              -> interface.prefix
+                - mult                -> interface.mult
+                - file_prefix         -> interface.file_prefix
+                - portmap_port_prefix -> interface.portmap_port_prefix
+
+        Returns:
+            interface: interface object
+        """
+        return create_interface(**interface_dict)
+
+    @staticmethod
+    def interface_text2dict(interface_text):
+        """Convert interface short notation text to dictionary.
+        Atributes:
+            interface_text (str): Short notation text. See `create_interface_from_text` for format.
+
+        Returns:
+            dict: Dictionary with interface attributes.
+        """
+        interface_flags = [
+            "genre",
+            ["-d", {"dest": "if_direction", "choices": ["", "manager", "subordinate"]}],
+            ["-m", {"dest": "mult"}],
+            ["-w", {"dest": "widths", "action": "append"}],  # create accepts dictionary
+            ["-P", {"dest": "params", "action": "append"}],
+            ["-p", {"dest": "prefix", "type": str}],
+            ["-pm", {"dest": "portmap_port_prefix", "type": str}],
+            ["-f", {"dest": "file_prefix", "type": str}],
+        ]
+        interface_dict = parse_short_notation_text(interface_text, interface_flags)
+        width_dict = {}
+        if "widths" in interface_dict and interface_dict["widths"]:
+            for width in interface_dict["widths"]:
+                if ":" in width:
+                    w_key, value = width.split(":", 1)
+                    width_dict[w_key] = value
+                else:
+                    raise ValueError(f"Invalid width specification: {width}")
+        interface_dict.update({"widths": width_dict})
+        return interface_dict
+
+    @staticmethod
+    def create_interface_from_text(interface_text):
+        """
+        Function to create interface object from short notation text.
+
+        Attributes:
+            interface_text (str): Short notation text. Object attributes are specified using the following format:
+                genre [-d direction] [-p prefix] [-m mult] [-f file_prefix] [-pm portmap_port_prefix] [-w WIDTH_W:val]+ -[-P PARAM:val]+
+                Examples:
+                    axi -d manager -p cpu_ -m 1 -f ctrl_cpu_ -pm controller_
+
+                    rom_sp -d subordinate -p boot_ -w ADDR_W:8 -w DATA_W:32
+
+                    axis -p output_ -P 'has_tlast'
+
+        Returns:
+            interface: interface object
+        """
+        return __class__.create_interface_from_dict(__class__.interface_text2dict(interface_text))
+
 
 #
 # IOb
@@ -2176,77 +2250,3 @@ if __name__ == "__main__":
             file_prefix="bla_",
         )
         interface.gen_all_vs_files()
-
-
-#
-# Other Py2HWSW interface methods
-#
-
-
-def create_interface_from_dict(interface_dict):
-    """
-    Function to create interface object from dictionary attributes.
-
-    Attributes:
-        interface_dict (dict): dictionary with values to initialize attributes of interface object.
-            This dictionary supports the following keys corresponding to the interface attributes:
-            - if_direction        -> interface.if_direction
-            - prefix              -> interface.prefix
-            - mult                -> interface.mult
-            - file_prefix         -> interface.file_prefix
-            - portmap_port_prefix -> interface.portmap_port_prefix
-
-    Returns:
-        interface: interface object
-    """
-    return create_interface(**interface_dict)
-
-
-def interface_text2dict(interface_text):
-    """Convert interface short notation text to dictionary.
-    Atributes:
-        interface_text (str): Short notation text. See `create_interface_from_text` for format.
-
-    Returns:
-        dict: Dictionary with interface attributes.
-    """
-    interface_flags = [
-        "genre",
-        ["-d", {"dest": "if_direction", "choices": ["", "manager", "subordinate"]}],
-        ["-m", {"dest": "mult"}],
-        ["-w", {"dest": "widths", "action": "append"}],  # create accepts dictionary
-        ["-P", {"dest": "params", "action": "append"}],
-        ["-p", {"dest": "prefix", "type": str}],
-        ["-pm", {"dest": "portmap_port_prefix", "type": str}],
-        ["-f", {"dest": "file_prefix", "type": str}],
-    ]
-    interface_dict = parse_short_notation_text(interface_text, interface_flags)
-    width_dict = {}
-    if "widths" in interface_dict and interface_dict["widths"]:
-        for width in interface_dict["widths"]:
-            if ":" in width:
-                w_key, value = width.split(":", 1)
-                width_dict[w_key] = value
-            else:
-                raise ValueError(f"Invalid width specification: {width}")
-    interface_dict.update({"widths": width_dict})
-    return interface_dict
-
-def create_interface_from_text(interface_text):
-    """
-    Function to create interface object from short notation text.
-
-    Attributes:
-        interface_text (str): Short notation text. Object attributes are specified using the following format:
-            genre [-d direction] [-p prefix] [-m mult] [-f file_prefix] [-pm portmap_port_prefix] [-w WIDTH_W:val]+ -[-P PARAM:val]+
-            Examples:
-                axi -d manager -p cpu_ -m 1 -f ctrl_cpu_ -pm controller_
-
-                rom_sp -d subordinate -p boot_ -w ADDR_W:8 -w DATA_W:32
-
-                axis -p output_ -P 'has_tlast'
-
-    Returns:
-        interface: interface object
-    """
-    return create_interface_from_dict(interface_text2dict(interface_text))

--- a/py2hwsw/src/iob_license.py
+++ b/py2hwsw/src/iob_license.py
@@ -23,67 +23,68 @@ class iob_license:
     year: int = date.today().year
     author: str = "IObundle, Lda"
 
+    @staticmethod
+    def update_license(core, *args, **kwargs):
+        """Updates existing core license with new attributes
+        param core: core object
+        param kwargs: license arguments
+        """
+        for k, v in kwargs.items():
+            if k not in dir(iob_license):
+                fail_with_msg(f"Unknown license attribute: {k}")
+            setattr(core.license, k, v)
 
-def update_license(core, *args, **kwargs):
-    """Updates existing core license with new attributes
-    param core: core object
-    param kwargs: license arguments
-    """
-    for k, v in kwargs.items():
-        if k not in dir(iob_license):
-            fail_with_msg(f"Unknown license attribute: {k}")
-        setattr(core.license, k, v)
+    #
+    # Other Py2HWSW interface methods
+    #
 
+    @staticmethod
+    def create_license_from_dict(license_dict):
+        """
+        Function to create iob_license object from dictionary attributes.
 
-#
-# Other Py2HWSW interface methods
-#
+        Attributes:
+            license_dict (dict): dictionary with values to initialize attributes of iob_license object.
+                This dictionary supports the following keys corresponding to the iob_license attributes:
+                - name -> iob_license.name
+                - year -> iob_license.year
+                - author -> iob_license.author
 
+        Returns:
+            iob_license: iob_license object
+        """
+        return iob_license(**license_dict)
 
-def create_license_from_dict(license_dict):
-    """
-    Function to create iob_license object from dictionary attributes.
+    @staticmethod
+    def license_text2dict(license_text):
+        """Convert license short notation text to dictionary.
+        Atributes:
+            license_text (str): Short notation text. See `create_license_from_text` for format.
 
-    Attributes:
-        license_dict (dict): dictionary with values to initialize attributes of iob_license object.
-            This dictionary supports the following keys corresponding to the iob_license attributes:
-            - name -> iob_license.name
-            - year -> iob_license.year
-            - author -> iob_license.author
+        Returns:
+            dict: Dictionary with license attributes.
+        """
+        license_flags = [
+            "name",
+            ["-y", {"dest": "year", "type": int}],
+            ["-a", {"dest": "author"}],
+        ]
+        return parse_short_notation_text(license_text, license_flags)
 
-    Returns:
-        iob_license: iob_license object
-    """
-    return iob_license(**license_dict)
+    @staticmethod
+    def create_license_from_text(license_text):
+        """
+        Function to create iob_license object from short notation text.
 
+        Attributes:
+            license_text (str): Short notation text. Object attributes are specified using the following format:
+                [name] [-y year] [-a author]
+                Example:
+                    MIT -y 2025 -a 'IObundle, Lda'
 
-def license_text2dict(license_text):
-    """Convert license short notation text to dictionary.
-    Atributes:
-        license_text (str): Short notation text. See `create_license_from_text` for format.
-
-    Returns:
-        dict: Dictionary with license attributes.
-    """
-    license_flags = [
-        "name",
-        ["-y", {"dest": "year", "type": int}],
-        ["-a", {"dest": "author"}],
-    ]
-    return parse_short_notation_text(license_text, license_flags)
-
-
-def create_license_from_text(license_text):
-    """
-    Function to create iob_license object from short notation text.
-
-    Attributes:
-        license_text (str): Short notation text. Object attributes are specified using the following format:
-            [name] [-y year] [-a author]
-            Example:
-                MIT -y 2025 -a 'IObundle, Lda'
-
-    Returns:
-        iob_license: iob_license object
-    """
-    return create_license_from_dict(license_text2dict(license_text))
+        Returns:
+            iob_license: iob_license object
+        """
+        return __class__.create_license_from_dict(
+            __class__.license_text2dict(license_text)
+        )

--- a/py2hwsw/src/iob_license.py
+++ b/py2hwsw/src/iob_license.py
@@ -39,7 +39,7 @@ class iob_license:
     #
 
     @staticmethod
-    def create_license_from_dict(license_dict):
+    def create_from_dict(license_dict):
         """
         Function to create iob_license object from dictionary attributes.
 
@@ -59,7 +59,7 @@ class iob_license:
     def license_text2dict(license_text):
         """Convert license short notation text to dictionary.
         Atributes:
-            license_text (str): Short notation text. See `create_license_from_text` for format.
+            license_text (str): Short notation text. See `create_from_text` for format.
 
         Returns:
             dict: Dictionary with license attributes.
@@ -72,7 +72,7 @@ class iob_license:
         return parse_short_notation_text(license_text, license_flags)
 
     @staticmethod
-    def create_license_from_text(license_text):
+    def create_from_text(license_text):
         """
         Function to create iob_license object from short notation text.
 
@@ -85,6 +85,4 @@ class iob_license:
         Returns:
             iob_license: iob_license object
         """
-        return __class__.create_license_from_dict(
-            __class__.license_text2dict(license_text)
-        )
+        return __class__.create_from_dict(__class__.license_text2dict(license_text))

--- a/py2hwsw/src/iob_module.py
+++ b/py2hwsw/src/iob_module.py
@@ -10,8 +10,10 @@ from iob_base import (
     fail_with_msg,
     prevent_instantiation,
 )
-from iob_globals import iob_globals, create_globals
+from iob_globals import iob_globals
 from iob_block import create_block
+
+create_globals = iob_globals.create_globals
 
 
 # @prevent_instantiation

--- a/py2hwsw/src/iob_parameter.py
+++ b/py2hwsw/src/iob_parameter.py
@@ -35,6 +35,61 @@ class iob_parameter:
         if not self.name:
             fail_with_msg("Every IOb Parameter must have a name!")
 
+    #
+    # Other Py2HWSW interface methods
+    #
+
+    @staticmethod
+    def create_iob_parameter_from_dict(iob_parameter_dict):
+        """
+        Function to create iob_iob_parameter object from dictionary attributes.
+
+        Attributes:
+            iob_parameter_dict (dict): dictionary with values to initialize attributes of iob_iob_parameter object.
+                This dictionary supports the following keys corresponding to the iob_parameter attributes:
+                - name -> iob_parameter.name
+                - val -> iob_parameter.val
+                - descr -> iob_parameter.descr
+
+        Returns:
+            iob_parameter: iob_parameter object
+        """
+        return iob_parameter(**iob_parameter_dict)
+
+    @staticmethod
+    def iob_parameter_text2dict(iob_parameter_text):
+        """Convert iob_parameter short notation text to dictionary.
+        Atributes:
+            iob_parameter_text (str): Short notation text. See `create_iob_parameter_from_text` for format.
+
+        Returns:
+            dict: Dictionary with iob_parameter attributes.
+        """
+        iob_parameter_flags = [
+            "name",
+            ["-v", {"dest": "val"}],
+            ["-d", {"dest": "descr"}],
+        ]
+        return parse_short_notation_text(iob_parameter_text, iob_parameter_flags)
+
+    @staticmethod
+    def create_iob_parameter_from_text(iob_parameter_text):
+        """
+        Function to create iob_parameter object from short notation text.
+
+        Attributes:
+            iob_parameter_text (str): Short notation text. Object attributes are specified using the following format:
+                [name] [-v value] [-d descr]
+                Example:
+                    my_param -v 42 -d 'My parameter description'
+
+        Returns:
+            iob_parameter: iob_parameter object
+        """
+        return __class__.create_iob_parameter_from_dict(
+            __class__.iob_parameter_text2dict(iob_parameter_text)
+        )
+
 
 @dataclass
 class iob_parameter_group:
@@ -57,175 +112,126 @@ class iob_parameter_group:
         if not self.name:
             fail_with_msg("IOb Parameter group name is not set", ValueError)
 
+    # attrs = [
+    #     "name",
+    #     ["-v", "val"],
+    #     ["-p", "iob_parameters", {"nargs": "+"}],
+    # ]
+    #
+    # @str_to_kwargs(attrs)
+    @staticmethod
+    def create_iob_parameter_group(core, *args, **kwargs):
+        """Creates a new IOb parameter group object and adds it to the core's iob_parameters list
+        param core: core object
+        """
+        try:
+            # Ensure 'iob_parameters' list exists
+            core.set_default_attribute("iob_parameters", [])
 
-attrs = [
-    "name",
-    ["-v", "val"],
-    ["-p", "iob_parameters", {"nargs": "+"}],
-]
+            general_group_ref = None
+            group_kwargs = kwargs
+            iob_parameters = kwargs.pop("iob_parameters", None)
+            # If kwargs provided a single iob_parameters instead of a group, then create a general group for it.
+            if iob_parameters is None:
+                iob_parameters = [kwargs]
+                group_kwargs = {
+                    "name": "general_iob_parameters",
+                    "descr": "General IOb Parameters group",
+                }
+                # Try to use existing "general_iob_parameters" group if was previously created
+                general_group_ref = find_obj_in_list(
+                    core.iob_parameters, "general_iob_parameters"
+                )
 
+            iob_parameters_obj_list = []
+            if type(iob_parameters) is list:
+                # Convert user iob_parameters dictionaries into 'iob_parameter' objects
+                iob_parameters_obj_list = create_obj_list(iob_parameters, iob_parameter)
+            else:
+                fail_with_msg(
+                    f"'iob_parameters' attribute must be a list. Error at iob_parameters group \"{group_kwargs.get('name', '')}\".\n{iob_parameters}",
+                    TypeError,
+                )
 
-@str_to_kwargs(attrs)
-def create_iob_parameter_group(core, *args, **kwargs):
-    """Creates a new IOb parameter group object and adds it to the core's iob_parameters list
-    param core: core object
-    """
-    try:
-        # Ensure 'iob_parameters' list exists
-        core.set_default_attribute("iob_parameters", [])
-
-        general_group_ref = None
-        group_kwargs = kwargs
-        iob_parameters = kwargs.pop("iob_parameters", None)
-        # If kwargs provided a single iob_parameters instead of a group, then create a general group for it.
-        if iob_parameters is None:
-            iob_parameters = [kwargs]
-            group_kwargs = {
-                "name": "general_iob_parameters",
-                "descr": "General IOb Parameters group",
-            }
-            # Try to use existing "general_iob_parameters" group if was previously created
-            general_group_ref = find_obj_in_list(
-                core.iob_parameters, "general_iob_parameters"
+            assert_attributes(
+                iob_parameter_group,
+                group_kwargs,
+                error_msg=f"Invalid {group_kwargs.get('name', '')} iob_parameters group attribute '[arg]'!",
             )
 
-        iob_parameters_obj_list = []
-        if type(iob_parameters) is list:
-            # Convert user iob_parameters dictionaries into 'iob_parameter' objects
-            iob_parameters_obj_list = create_obj_list(iob_parameters, iob_parameter)
-        else:
-            fail_with_msg(
-                f"'iob_parameters' attribute must be a list. Error at iob_parameters group \"{group_kwargs.get('name', '')}\".\n{iob_parameters}",
-                TypeError,
+            # Use existing "general_iob_parameters" group if possible
+            if general_group_ref:
+                general_group_ref.iob_parameters += iob_parameters_obj_list
+            else:
+                iob_parameters_group = iob_parameter_group(
+                    iob_parameters=iob_parameters_obj_list, **group_kwargs
+                )
+                core.iob_parameters.append(iob_parameters_group)
+        except Exception:
+            add_traceback_msg(
+                f"Failed to create iob_parameter/group '{kwargs['name']}'."
             )
+            raise
 
-        assert_attributes(
-            iob_parameter_group,
-            group_kwargs,
-            error_msg=f"Invalid {group_kwargs.get('name', '')} iob_parameters group attribute '[arg]'!",
+    #
+    # Other Py2HWSW interface methods
+    #
+
+    @staticmethod
+    def create_iob_parameter_group_from_dict(iob_parameter_group_dict):
+        """
+        Function to create iob_parameter_group object from dictionary attributes.
+
+        Attributes:
+            iob_parameter_group_dict (dict): dictionary with values to initialize attributes of iob_parameter_group object.
+                This dictionary supports the following keys corresponding to the iob_parameter_group attributes:
+                - name -> iob_parameter_group.name
+                - descr -> iob_parameter_group.descr
+                - iob_parameters -> iob_parameter_group.iob_parameters
+                - doc_clearpage -> iob_parameter_group.doc_clearpage
+
+        Returns:
+            iob_parameter_group: iob_parameter_group object
+        """
+        # Convert dictionary elements to objects
+        kwargs = iob_parameter_group_dict.copy()
+        kwargs["iob_parameters"] = [
+            __class__.create_iob_parameter_from_dict(i)
+            for i in iob_parameter_group_dict["iob_parameters"]
+        ]
+        return iob_parameter_group(**kwargs)
+
+    @staticmethod
+    def iob_parameter_group_text2dict(iob_parameter_group_text):
+        iob_parameter_group_flags = [
+            "name",
+            ["-d", {"dest": "descr"}],
+            ["-P", {"dest": "iob_parameters", "action": "append"}],
+            ["-doc_clearpage", {"dest": "doc_clearpage", "action": "store_true"}],
+        ]
+        iob_parameter_group_dict = parse_short_notation_text(
+            iob_parameter_group_text, iob_parameter_group_flags
         )
+        # Special processing for iob_parameter subflags
+        params: list[iob_parameter] = []
+        for param_text in iob_parameter_group_dict.get("iob_parameters", []):
+            params.append(__class__.iob_parameter_text2dict(param_text))
+        # replace "iob_parameters" short notation text with list of IOb parameter dicts
+        iob_parameter_group_dict.update({"iob_parameters": params})
+        return iob_parameter_group_dict
 
-        # Use existing "general_iob_parameters" group if possible
-        if general_group_ref:
-            general_group_ref.iob_parameters += iob_parameters_obj_list
-        else:
-            iob_parameters_group = iob_parameter_group(
-                iob_parameters=iob_parameters_obj_list, **group_kwargs
-            )
-            core.iob_parameters.append(iob_parameters_group)
-    except Exception:
-        add_traceback_msg(f"Failed to create iob_parameter/group '{kwargs['name']}'.")
-        raise
+    @staticmethod
+    def create_iob_parameter_group_from_text(iob_parameter_group_text):
+        """
+        Function to create iob_parameter_group object from short notation text.
 
+        Attributes:
+            iob_parameter_group_text (str): Short notation text. Object attributes are specified using the following format:
+                TODO
 
-#
-# Other Py2HWSW interface methods
-#
-
-
-def create_iob_parameter_from_dict(iob_parameter_dict):
-    """
-    Function to create iob_iob_parameter object from dictionary attributes.
-
-    Attributes:
-        iob_parameter_dict (dict): dictionary with values to initialize attributes of iob_iob_parameter object.
-            This dictionary supports the following keys corresponding to the iob_parameter attributes:
-            - name -> iob_parameter.name
-            - val -> iob_parameter.val
-            - descr -> iob_parameter.descr
-
-    Returns:
-        iob_parameter: iob_parameter object
-    """
-    return iob_parameter(**iob_parameter_dict)
-
-
-def iob_parameter_text2dict(iob_parameter_text):
-    """Convert iob_parameter short notation text to dictionary.
-    Atributes:
-        iob_parameter_text (str): Short notation text. See `create_iob_parameter_from_text` for format.
-
-    Returns:
-        dict: Dictionary with iob_parameter attributes.
-    """
-    iob_parameter_flags = [
-        "name",
-        ["-v", {"dest": "val"}],
-        ["-d", {"dest": "descr"}],
-    ]
-    return parse_short_notation_text(iob_parameter_text, iob_parameter_flags)
-
-
-def create_iob_parameter_from_text(iob_parameter_text):
-    """
-    Function to create iob_parameter object from short notation text.
-
-    Attributes:
-        iob_parameter_text (str): Short notation text. Object attributes are specified using the following format:
-            [name] [-v value] [-d descr]
-            Example:
-                my_param -v 42 -d 'My parameter description'
-
-    Returns:
-        iob_parameter: iob_parameter object
-    """
-    return create_iob_parameter_from_dict(iob_parameter_text2dict(iob_parameter_text))
-
-
-def create_iob_parameter_group_from_dict(iob_parameter_group_dict):
-    """
-    Function to create iob_parameter_group object from dictionary attributes.
-
-    Attributes:
-        iob_parameter_group_dict (dict): dictionary with values to initialize attributes of iob_parameter_group object.
-            This dictionary supports the following keys corresponding to the iob_parameter_group attributes:
-            - name -> iob_parameter_group.name
-            - descr -> iob_parameter_group.descr
-            - iob_parameters -> iob_parameter_group.iob_parameters
-            - doc_clearpage -> iob_parameter_group.doc_clearpage
-
-    Returns:
-        iob_parameter_group: iob_parameter_group object
-    """
-    # Convert dictionary elements to objects
-    kwargs = iob_parameter_group_dict.copy()
-    kwargs["iob_parameters"] = [
-        create_iob_parameter_from_dict(i)
-        for i in iob_parameter_group_dict["iob_parameters"]
-    ]
-    return iob_parameter_group(**kwargs)
-
-
-def iob_parameter_group_text2dict(iob_parameter_group_text):
-    iob_parameter_group_flags = [
-        "name",
-        ["-d", {"dest": "descr"}],
-        ["-P", {"dest": "iob_parameters", "action": "append"}],
-        ["-doc_clearpage", {"dest": "doc_clearpage", "action": "store_true"}],
-    ]
-    iob_parameter_group_dict = parse_short_notation_text(
-        iob_parameter_group_text, iob_parameter_group_flags
-    )
-    # Special processing for iob_parameter subflags
-    params: list[iob_parameter] = []
-    for param_text in iob_parameter_group_dict.get("iob_parameters", []):
-        params.append(iob_parameter_text2dict(param_text))
-    # replace "iob_parameters" short notation text with list of IOb parameter dicts
-    iob_parameter_group_dict.update({"iob_parameters": params})
-    return iob_parameter_group_dict
-
-
-def create_iob_parameter_group_from_text(iob_parameter_group_text):
-    """
-    Function to create iob_parameter_group object from short notation text.
-
-    Attributes:
-        iob_parameter_group_text (str): Short notation text. Object attributes are specified using the following format:
-            TODO
-
-    Returns:
-        iob_parameter_group: iob_parameter_group object
-    """
-    return create_iob_parameter_group_from_dict(
-        iob_parameter_group_text2dict(iob_parameter_group_text)
-    )
+        Returns:
+            iob_parameter_group: iob_parameter_group object
+        """
+        return __class__.create_iob_parameter_group_from_dict(
+            __class__.iob_parameter_group_text2dict(iob_parameter_group_text)
+        )

--- a/py2hwsw/src/iob_parameter.py
+++ b/py2hwsw/src/iob_parameter.py
@@ -40,7 +40,7 @@ class iob_parameter:
     #
 
     @staticmethod
-    def create_iob_parameter_from_dict(iob_parameter_dict):
+    def create_from_dict(iob_parameter_dict):
         """
         Function to create iob_iob_parameter object from dictionary attributes.
 
@@ -60,7 +60,7 @@ class iob_parameter:
     def iob_parameter_text2dict(iob_parameter_text):
         """Convert iob_parameter short notation text to dictionary.
         Atributes:
-            iob_parameter_text (str): Short notation text. See `create_iob_parameter_from_text` for format.
+            iob_parameter_text (str): Short notation text. See `create_from_text` for format.
 
         Returns:
             dict: Dictionary with iob_parameter attributes.
@@ -73,7 +73,7 @@ class iob_parameter:
         return parse_short_notation_text(iob_parameter_text, iob_parameter_flags)
 
     @staticmethod
-    def create_iob_parameter_from_text(iob_parameter_text):
+    def create_from_text(iob_parameter_text):
         """
         Function to create iob_parameter object from short notation text.
 
@@ -86,7 +86,7 @@ class iob_parameter:
         Returns:
             iob_parameter: iob_parameter object
         """
-        return __class__.create_iob_parameter_from_dict(
+        return __class__.create_from_dict(
             __class__.iob_parameter_text2dict(iob_parameter_text)
         )
 
@@ -178,7 +178,7 @@ class iob_parameter_group:
     #
 
     @staticmethod
-    def create_iob_parameter_group_from_dict(iob_parameter_group_dict):
+    def create_from_dict(iob_parameter_group_dict):
         """
         Function to create iob_parameter_group object from dictionary attributes.
 
@@ -196,7 +196,7 @@ class iob_parameter_group:
         # Convert dictionary elements to objects
         kwargs = iob_parameter_group_dict.copy()
         kwargs["iob_parameters"] = [
-            __class__.create_iob_parameter_from_dict(i)
+            __class__.create_from_dict(i)
             for i in iob_parameter_group_dict["iob_parameters"]
         ]
         return iob_parameter_group(**kwargs)
@@ -221,7 +221,7 @@ class iob_parameter_group:
         return iob_parameter_group_dict
 
     @staticmethod
-    def create_iob_parameter_group_from_text(iob_parameter_group_text):
+    def create_from_text(iob_parameter_group_text):
         """
         Function to create iob_parameter_group object from short notation text.
 
@@ -232,6 +232,6 @@ class iob_parameter_group:
         Returns:
             iob_parameter_group: iob_parameter_group object
         """
-        return __class__.create_iob_parameter_group_from_dict(
+        return __class__.create_from_dict(
             __class__.iob_parameter_group_text2dict(iob_parameter_group_text)
         )

--- a/py2hwsw/src/iob_port.py
+++ b/py2hwsw/src/iob_port.py
@@ -61,7 +61,7 @@ class iob_port:
     #
 
     @staticmethod
-    def create_port_from_dict(port_dict):
+    def create_from_dict(port_dict):
         """
         Function to create iob_port object from dictionary attributes.
 
@@ -88,7 +88,7 @@ class iob_port:
     def port_text2dict(port_text):
         """Convert port short notation text to dictionary.
         Atributes:
-            port_text (str): Short notation text. See `create_port_from_text` for format.
+            port_text (str): Short notation text. See `create_from_text` for format.
 
         Returns:
             dict: Dictionary with port attributes.
@@ -116,7 +116,7 @@ class iob_port:
         return port_dict
 
     @staticmethod
-    def create_port_from_text(port_text):
+    def create_from_text(port_text):
         """
         Function to create iob_port object from short notation text.
 
@@ -129,4 +129,4 @@ class iob_port:
         Returns:
             iob_port: iob_port object
         """
-        return __class__.create_port_from_dict(__class__.port_text2dict(port_text))
+        return __class__.create_from_dict(__class__.port_text2dict(port_text))

--- a/py2hwsw/src/iob_port.py
+++ b/py2hwsw/src/iob_port.py
@@ -51,83 +51,82 @@ class iob_port:
         except ValueError:
             return port_width
 
+    @staticmethod
+    def port_obj_list_process(port):
+        """Process ports for `find_obj_in_list()`"""
+        return port.wire
 
-def port_obj_list_process(port):
-    """Process ports for `find_obj_in_list()`"""
-    return port.wire
+    #
+    # Other Py2HWSW interface methods
+    #
 
+    @staticmethod
+    def create_port_from_dict(port_dict):
+        """
+        Function to create iob_port object from dictionary attributes.
 
-#
-# Other Py2HWSW interface methods
-#
+        Attributes:
+            port_dict (dict): dictionary with values to initialize attributes of iob_port object.
+                This dictionary supports the following keys corresponding to the iob_port attributes:
+                - wire -> iob_port.wire
+                - doc_only -> iob_port.doc_only
+                - doc_clearpage -> iob_port.doc_clearpage
 
+        Returns:
+            iob_port: iob_port object
+        """
+        # Create a wire for this port
+        iob_wire_obj = iob_wire(name=port_dict["name"], width=port_dict["width"])
 
-def create_port_from_dict(port_dict):
-    """
-    Function to create iob_port object from dictionary attributes.
+        # Get port direction form name suffix
+        dir_suffix = port_dict["name"].split("_")[-1]
+        dirs = {"i": "input", "o": "output", "io": "inout"}
 
-    Attributes:
-        port_dict (dict): dictionary with values to initialize attributes of iob_port object.
-            This dictionary supports the following keys corresponding to the iob_port attributes:
-            - wire -> iob_port.wire
-            - doc_only -> iob_port.doc_only
-            - doc_clearpage -> iob_port.doc_clearpage
+        return iob_port(wire=iob_wire_obj, direction=dirs[dir_suffix])
 
-    Returns:
-        iob_port: iob_port object
-    """
-    # Create a wire for this port
-    iob_wire_obj = iob_wire(name=port_dict["name"], width=port_dict["width"])
+    @staticmethod
+    def port_text2dict(port_text):
+        """Convert port short notation text to dictionary.
+        Atributes:
+            port_text (str): Short notation text. See `create_port_from_text` for format.
 
-    # Get port direction form name suffix
-    dir_suffix = port_dict["name"].split("_")[-1]
-    dirs = {"i": "input", "o": "output", "io": "inout"}
+        Returns:
+            dict: Dictionary with port attributes.
+        """
+        port_flags = [
+            "name",
+            ["-i", {"dest": "interface"}],
+            ["-w", {"dest": "wires", "action": "append"}],
+            ["-d", {"dest": "descr", "nargs": "?"}],
+            ["-doc", {"dest": "doc_only", "action": "store_true"}],
+            ["-doc_clearpage", {"dest": "doc_clearpage", "action": "store_true"}],
+        ]
+        port_dict = parse_short_notation_text(port_text, port_flags)
+        port_wires = []
+        for s in port_dict.get("wires", []):
+            try:
+                [s_name, s_width] = s.split(":")
+            except ValueError:
+                fail_with_msg(
+                    f"Invalid wire format '{s}'! Expected 'name:width' format.",
+                    ValueError,
+                )
+            port_wires.append({"name": s_name, "width": s_width})
+        port_dict.update({"wires": port_wires})
+        return port_dict
 
-    return iob_port(wire=iob_wire_obj, direction=dirs[dir_suffix])
+    @staticmethod
+    def create_port_from_text(port_text):
+        """
+        Function to create iob_port object from short notation text.
 
+        Attributes:
+            port_text (str): Short notation text. Object attributes are specified using the following format:
+                name [-i interface] [-d descr] [-s wire_name:width]+ [-doc] [-doc_clearpage]
+                Example:
+                    control -d 'control bus' -s start_i:1 -s done_o:1 -s cmd_i:CMD_W -doc
 
-def port_text2dict(port_text):
-    """Convert port short notation text to dictionary.
-    Atributes:
-        port_text (str): Short notation text. See `create_port_from_text` for format.
-
-    Returns:
-        dict: Dictionary with port attributes.
-    """
-    port_flags = [
-        "name",
-        ["-i", {"dest": "interface"}],
-        ["-w", {"dest": "wires", "action": "append"}],
-        ["-d", {"dest": "descr", "nargs": "?"}],
-        ["-doc", {"dest": "doc_only", "action": "store_true"}],
-        ["-doc_clearpage", {"dest": "doc_clearpage", "action": "store_true"}],
-    ]
-    port_dict = parse_short_notation_text(port_text, port_flags)
-    port_wires = []
-    for s in port_dict.get("wires", []):
-        try:
-            [s_name, s_width] = s.split(":")
-        except ValueError:
-            fail_with_msg(
-                f"Invalid wire format '{s}'! Expected 'name:width' format.",
-                ValueError,
-            )
-        port_wires.append({"name": s_name, "width": s_width})
-    port_dict.update({"wires": port_wires})
-    return port_dict
-
-
-def create_port_from_text(port_text):
-    """
-    Function to create iob_port object from short notation text.
-
-    Attributes:
-        port_text (str): Short notation text. Object attributes are specified using the following format:
-            name [-i interface] [-d descr] [-s wire_name:width]+ [-doc] [-doc_clearpage]
-            Example:
-                control -d 'control bus' -s start_i:1 -s done_o:1 -s cmd_i:CMD_W -doc
-
-    Returns:
-        iob_port: iob_port object
-    """
-    return create_port_from_dict(port_text2dict(port_text))
+        Returns:
+            iob_port: iob_port object
+        """
+        return __class__.create_port_from_dict(__class__.port_text2dict(port_text))

--- a/py2hwsw/src/iob_portmap.py
+++ b/py2hwsw/src/iob_portmap.py
@@ -11,9 +11,11 @@ from iob_base import (
     empty_list,
 )
 import iob_colors
-from iob_wire import get_real_wire, iob_wire_reference
+from iob_wire import iob_wire, iob_wire_reference
 from iob_bus import iob_bus
 from iob_port import iob_port
+
+get_real_wire = iob_wire.get_real_wire
 
 
 @dataclass
@@ -145,96 +147,95 @@ class iob_portmap:
         self.e_connect = bus
         self.e_connect_bit_slices = bit_slices
 
+    @staticmethod
+    def get_portmap_port(portmap):
+        """Given a portmap reference, return the associated port"""
+        port = None
+        if isinstance(portmap, iob_portmap):
+            port = portmap.port
+        return port
 
-def get_portmap_port(portmap):
-    """Given a portmap reference, return the associated port"""
-    port = None
-    if isinstance(portmap, iob_portmap):
-        port = portmap.port
-    return port
+    #
+    # Other Py2HWSW interface methods
+    #
 
+    @staticmethod
+    def create_portmap_from_dict(portmap_dict):
+        """
+        Function to create iob_portmap object from dictionary attributes.
 
-#
-# Other Py2HWSW interface methods
-#
+        Attributes:
+            portmap_dict (dict): dictionary with values to initialize attributes of iob_portmap object.
+                Dictionary format:
+                {
+                    "port1_name": "external_connection1_name",
+                    "port2_name": "external_connection2_name",
+                    "port3_name": ("external_connection3_name", ["bit_slice_1", "bit_slice_2", ...]),
+                }
+                Dictionary element to attribute mapping:
+                port1_name -> iob_portmap.port
+                external_connection1_name -> iob_portmap.e_connect
+                ["bit_slice_1", "bit_slice_2", ...] -> iob_portmap.e_connect_bit_slices
 
+                Bit slices may perform multiple functions:
+                - Slice bits from a wire that is being connected.
+                  For example, if we have a wire (iob_addr_wire) with 32 bits, from a bus (iob_bus_bus), and we want to connect it to a port (iob_bus_port) that only accepts an address of 8 bits, we could use:
+                  "iob_bus_port": ("iob_bus_bus", ["iob_addr_wire[7:0]"]),
+                - Connect extra wires that do not exist in the bus.
+                  For example, if we have a wire (independent_iob_data_wire) that is not included in the bus (iob_bus_bus), but exists in the port (iob_bus_port), we could use:
+                  "iob_bus_port": ("iob_bus_bus", ["iob_data_wire_i: independent_iob_data_wire"]),
+                  If we didn't have the independent_iob_data_wire, we could instead connect that port's wire to a constant value or high impedance, like so:
+                  "iob_bus_port": ("iob_bus_bus", ["iob_data_wire_i: 'b1"]),
+                  "iob_bus_port": ("iob_bus_bus", ["iob_data_wire_i: 'bz"]),
 
-def create_portmap_from_dict(portmap_dict):
-    """
-    Function to create iob_portmap object from dictionary attributes.
-
-    Attributes:
-        portmap_dict (dict): dictionary with values to initialize attributes of iob_portmap object.
-            Dictionary format:
-            {
-                "port1_name": "external_connection1_name",
-                "port2_name": "external_connection2_name",
-                "port3_name": ("external_connection3_name", ["bit_slice_1", "bit_slice_2", ...]),
-            }
-            Dictionary element to attribute mapping:
-            port1_name -> iob_portmap.port
-            external_connection1_name -> iob_portmap.e_connect
-            ["bit_slice_1", "bit_slice_2", ...] -> iob_portmap.e_connect_bit_slices
-
-            Bit slices may perform multiple functions:
-            - Slice bits from a wire that is being connected.
-              For example, if we have a wire (iob_addr_wire) with 32 bits, from a bus (iob_bus_bus), and we want to connect it to a port (iob_bus_port) that only accepts an address of 8 bits, we could use:
-              "iob_bus_port": ("iob_bus_bus", ["iob_addr_wire[7:0]"]),
-            - Connect extra wires that do not exist in the bus.
-              For example, if we have a wire (independent_iob_data_wire) that is not included in the bus (iob_bus_bus), but exists in the port (iob_bus_port), we could use:
-              "iob_bus_port": ("iob_bus_bus", ["iob_data_wire_i: independent_iob_data_wire"]),
-              If we didn't have the independent_iob_data_wire, we could instead connect that port's wire to a constant value or high impedance, like so:
-              "iob_bus_port": ("iob_bus_bus", ["iob_data_wire_i: 'b1"]),
-              "iob_bus_port": ("iob_bus_bus", ["iob_data_wire_i: 'bz"]),
-
-              # FIXME: For some reason, connecting extra wires with bit slices only works for connections between ports and buses that have standard interfaces! Not sure why its implemented this way: https://github.com/IObundle/py2hwsw/blob/0679fc64576380c19be96567efb5093667eeb9fd/py2hwsw/scripts/block_gen.py#L121
-              # Also, I'm not sure we can connect them to constants/high impedance.
-              # It seems to be possible to connect ports to constants like so: https://github.com/IObundle/py2hwsw/pull/236
-
+                  # FIXME: For some reason, connecting extra wires with bit slices only works for connections between ports and buses that have standard interfaces! Not sure why its implemented this way: https://github.com/IObundle/py2hwsw/blob/0679fc64576380c19be96567efb5093667eeb9fd/py2hwsw/scripts/block_gen.py#L121
+                  # Also, I'm not sure we can connect them to constants/high impedance.
+                  # It seems to be possible to connect ports to constants like so: https://github.com/IObundle/py2hwsw/pull/236
 
 
-    Returns:
-        list[iob_portmap]: List of iob_portmap objects
-    """
-    portmap_list = []
-    for port_name, connection in portmap_dict.items():
 
-        # Extract external bus and bit slices from connection
-        bit_slices = []
-        if type(connection) is str:
-            external_bus_name = connection
-        elif type(connection) is tuple:
-            external_bus_name = connection[0]
-            bit_slices = connection[1]
-            if type(bit_slices) is not list:
-                fail_with_msg(
-                    f"Second element of tuple must be a list of bit slices/connections: {connection}"
-                )
-        else:
-            fail_with_msg(f"Invalid connection value: {connection}")
+        Returns:
+            list[iob_portmap]: List of iob_portmap objects
+        """
+        portmap_list = []
+        for port_name, connection in portmap_dict.items():
 
-        # Create portmap and add to list
-        portmap = iob_portmap(
-            port_name=port_name,
-            e_connect=external_bus_name,
-            e_connect_bit_slices=bit_slices,
-        )
-        portmap_list.append(portmap)
+            # Extract external bus and bit slices from connection
+            bit_slices = []
+            if type(connection) is str:
+                external_bus_name = connection
+            elif type(connection) is tuple:
+                external_bus_name = connection[0]
+                bit_slices = connection[1]
+                if type(bit_slices) is not list:
+                    fail_with_msg(
+                        f"Second element of tuple must be a list of bit slices/connections: {connection}"
+                    )
+            else:
+                fail_with_msg(f"Invalid connection value: {connection}")
 
-    return portmap_list
+            # Create portmap and add to list
+            portmap = iob_portmap(
+                port_name=port_name,
+                e_connect=external_bus_name,
+                e_connect_bit_slices=bit_slices,
+            )
+            portmap_list.append(portmap)
 
+        return portmap_list
 
-def create_portmap_from_text(portmap_text):
-    """
-    Function to create iob_portmap object from short notation text.
+    @staticmethod
+    def create_portmap_from_text(portmap_text):
+        """
+        Function to create iob_portmap object from short notation text.
 
-    Attributes:
-        portmap_text (str): Short notation text. Object attributes are specified using the following format:
-            TODO
+        Attributes:
+            portmap_text (str): Short notation text. Object attributes are specified using the following format:
+                TODO
 
-    Returns:
-        iob_portmap: iob_portmap object
-    """
-    portmap_dict = {}
-    # TODO: parse short notation text
-    return iob_portmap(**portmap_dict)
+        Returns:
+            iob_portmap: iob_portmap object
+        """
+        portmap_dict = {}
+        # TODO: parse short notation text
+        return iob_portmap(**portmap_dict)

--- a/py2hwsw/src/iob_portmap.py
+++ b/py2hwsw/src/iob_portmap.py
@@ -160,7 +160,7 @@ class iob_portmap:
     #
 
     @staticmethod
-    def create_portmap_from_dict(portmap_dict):
+    def create_from_dict(portmap_dict):
         """
         Function to create iob_portmap object from dictionary attributes.
 
@@ -225,7 +225,7 @@ class iob_portmap:
         return portmap_list
 
     @staticmethod
-    def create_portmap_from_text(portmap_text):
+    def create_from_text(portmap_text):
         """
         Function to create iob_portmap object from short notation text.
 

--- a/py2hwsw/src/iob_snippet.py
+++ b/py2hwsw/src/iob_snippet.py
@@ -18,47 +18,48 @@ class iob_snippet:
 
     pass
 
+    #
+    # Other Py2HWSW interface methods
+    #
 
-#
-# Other Py2HWSW interface methods
-#
+    @staticmethod
+    def create_snippet_from_dict(snippet_dict):
+        """
+        Function to create iob_snippet object from dictionary attributes.
 
+        Attributes:
+            snippet_dict (dict): dictionary with values to initialize attributes of iob_snippet object.
+                This dictionary supports the following keys corresponding to the iob_snippet attributes:
+                - verilog_code -> iob_snippet.verilog_code
 
-def create_snippet_from_dict(snippet_dict):
-    """
-    Function to create iob_snippet object from dictionary attributes.
+        Returns:
+            iob_snippet: iob_snippet object
+        """
+        return iob_snippet(**snippet_dict)
 
-    Attributes:
-        snippet_dict (dict): dictionary with values to initialize attributes of iob_snippet object.
-            This dictionary supports the following keys corresponding to the iob_snippet attributes:
-            - verilog_code -> iob_snippet.verilog_code
+    @staticmethod
+    def snippet_text2dict(snippet_text):
+        """Convert snippet short notation text to dictionary.
+        Atributes:
+            snippet_text (str): Short notation text. See `create_snippet_from_text` for format.
 
-    Returns:
-        iob_snippet: iob_snippet object
-    """
-    return iob_snippet(**snippet_dict)
+        Returns:
+            dict: Dictionary with snippet attributes.
+        """
+        return {"verilog_code": snippet_text}
 
+    @staticmethod
+    def create_snippet_from_text(snippet_text):
+        """
+        Function to create iob_snippet object from short notation text.
 
-def snippet_text2dict(snippet_text):
-    """Convert snippet short notation text to dictionary.
-    Atributes:
-        snippet_text (str): Short notation text. See `create_snippet_from_text` for format.
+        Attributes:
+            snippet_text (str): Short notation text. Object attributes are specified using the following format:
+                [snippet_text]
 
-    Returns:
-        dict: Dictionary with snippet attributes.
-    """
-    return {"verilog_code": snippet_text}
-
-
-def create_snippet_from_text(snippet_text):
-    """
-    Function to create iob_snippet object from short notation text.
-
-    Attributes:
-        snippet_text (str): Short notation text. Object attributes are specified using the following format:
-            [snippet_text]
-
-    Returns:
-        iob_snippet: iob_snippet object
-    """
-    return create_snippet_from_dict(snippet_text2dict(snippet_text))
+        Returns:
+            iob_snippet: iob_snippet object
+        """
+        return __class__.create_snippet_from_dict(
+            __class__.snippet_text2dict(snippet_text)
+        )

--- a/py2hwsw/src/iob_snippet.py
+++ b/py2hwsw/src/iob_snippet.py
@@ -23,7 +23,7 @@ class iob_snippet:
     #
 
     @staticmethod
-    def create_snippet_from_dict(snippet_dict):
+    def create_from_dict(snippet_dict):
         """
         Function to create iob_snippet object from dictionary attributes.
 
@@ -41,7 +41,7 @@ class iob_snippet:
     def snippet_text2dict(snippet_text):
         """Convert snippet short notation text to dictionary.
         Atributes:
-            snippet_text (str): Short notation text. See `create_snippet_from_text` for format.
+            snippet_text (str): Short notation text. See `create_from_text` for format.
 
         Returns:
             dict: Dictionary with snippet attributes.
@@ -49,7 +49,7 @@ class iob_snippet:
         return {"verilog_code": snippet_text}
 
     @staticmethod
-    def create_snippet_from_text(snippet_text):
+    def create_from_text(snippet_text):
         """
         Function to create iob_snippet object from short notation text.
 
@@ -60,6 +60,4 @@ class iob_snippet:
         Returns:
             iob_snippet: iob_snippet object
         """
-        return __class__.create_snippet_from_dict(
-            __class__.snippet_text2dict(snippet_text)
-        )
+        return __class__.create_from_dict(__class__.snippet_text2dict(snippet_text))

--- a/py2hwsw/src/iob_wire.py
+++ b/py2hwsw/src/iob_wire.py
@@ -53,6 +53,72 @@ class iob_wire:
         except ValueError:
             return width_v
 
+    @staticmethod
+    def get_real_wire(wire):
+        """Given a wire reference, follow the reference (recursively) and
+        return the real wire
+        """
+        while isinstance(wire, iob_wire_reference):
+            wire = wire.wire
+        return wire
+
+    @staticmethod
+    def remove_wire_direction_suffixes(wire_list):
+        """Given a wire list (usually from a port) that includes direction suffixes in their names (like _i, _o, _io),
+        return a new list with the suffixes removed"""
+        new_list = copy.deepcopy(wire_list)
+        for wire in new_list:
+            wire.name = wire.name.rsplit("_", 1)[0]
+        return new_list
+
+    #
+    # Other Py2HWSW interface methods
+    #
+
+    @staticmethod
+    def create_wire_from_dict(wire_dict):
+        """
+        Function to create iob_wire object from dictionary attributes.
+
+        Attributes:
+            wire_dict (dict): dictionary with values to initialize attributes of iob_wire object.
+                This dictionary supports the following keys corresponding to the iob_wire attributes:
+                - name          -> iob_wire.name
+                - width         -> iob_wire.width
+                - descr         -> iob_wire.descr
+                - isvar         -> iob_wire.isvar
+
+        Returns:
+            iob_wire: iob_wire object
+        """
+        return iob_wire(**wire_dict)
+
+    @staticmethod
+    def wire_text2dict(wire_text):
+        wire_flags = [
+            "name",
+            ["-w", {"dest": "width"}],
+            ["-v", {"dest": "isvar", "action": "store_true"}],
+            ["-d", {"dest": "descr", "nargs": "?"}],
+        ]
+        return parse_short_notation_text(wire_text, wire_flags)
+
+    @staticmethod
+    def create_wire_from_text(wire_text):
+        """
+        Function to create iob_wire object from short notation text.
+
+        Attributes:
+            wire_text (str): Short notation text. Object attributes are specified using the following format:
+                name [-w width] [-d descr] [-v (enables isvar)]
+                Example:
+                    en -w 1 -d 'Enable wire' -v
+
+        Returns:
+            iob_wire: iob_wire object
+        """
+        return __class__.create_wire_from_dict(__class__.wire_text2dict(wire_text))
+
 
 @dataclass
 class iob_wire_reference:
@@ -61,70 +127,3 @@ class iob_wire_reference:
     """
 
     wire: iob_wire | None = None
-
-
-def get_real_wire(wire):
-    """Given a wire reference, follow the reference (recursively) and
-    return the real wire
-    """
-    while isinstance(wire, iob_wire_reference):
-        wire = wire.wire
-    return wire
-
-
-def remove_wire_direction_suffixes(wire_list):
-    """Given a wire list (usually from a port) that includes direction suffixes in their names (like _i, _o, _io),
-    return a new list with the suffixes removed"""
-    new_list = copy.deepcopy(wire_list)
-    for wire in new_list:
-        wire.name = wire.name.rsplit("_", 1)[0]
-    return new_list
-
-
-#
-# Other Py2HWSW interface methods
-#
-
-
-def create_wire_from_dict(wire_dict):
-    """
-    Function to create iob_wire object from dictionary attributes.
-
-    Attributes:
-        wire_dict (dict): dictionary with values to initialize attributes of iob_wire object.
-            This dictionary supports the following keys corresponding to the iob_wire attributes:
-            - name          -> iob_wire.name
-            - width         -> iob_wire.width
-            - descr         -> iob_wire.descr
-            - isvar         -> iob_wire.isvar
-
-    Returns:
-        iob_wire: iob_wire object
-    """
-    return iob_wire(**wire_dict)
-
-
-def wire_text2dict(wire_text):
-    wire_flags = [
-        "name",
-        ["-w", {"dest": "width"}],
-        ["-v", {"dest": "isvar", "action": "store_true"}],
-        ["-d", {"dest": "descr", "nargs": "?"}],
-    ]
-    return parse_short_notation_text(wire_text, wire_flags)
-
-
-def create_wire_from_text(wire_text):
-    """
-    Function to create iob_wire object from short notation text.
-
-    Attributes:
-        wire_text (str): Short notation text. Object attributes are specified using the following format:
-            name [-w width] [-d descr] [-v (enables isvar)]
-            Example:
-                en -w 1 -d 'Enable wire' -v
-
-    Returns:
-        iob_wire: iob_wire object
-    """
-    return create_wire_from_dict(wire_text2dict(wire_text))

--- a/py2hwsw/src/iob_wire.py
+++ b/py2hwsw/src/iob_wire.py
@@ -76,7 +76,7 @@ class iob_wire:
     #
 
     @staticmethod
-    def create_wire_from_dict(wire_dict):
+    def create_from_dict(wire_dict):
         """
         Function to create iob_wire object from dictionary attributes.
 
@@ -104,7 +104,7 @@ class iob_wire:
         return parse_short_notation_text(wire_text, wire_flags)
 
     @staticmethod
-    def create_wire_from_text(wire_text):
+    def create_from_text(wire_text):
         """
         Function to create iob_wire object from short notation text.
 
@@ -117,7 +117,7 @@ class iob_wire:
         Returns:
             iob_wire: iob_wire object
         """
-        return __class__.create_wire_from_dict(__class__.wire_text2dict(wire_text))
+        return __class__.create_from_dict(__class__.wire_text2dict(wire_text))
 
 
 @dataclass


### PR DESCRIPTION
This PR has no functional code changes. The setup/build behavior has not changed.

- Refactor py2hwsw code
  Move methods, that were previously outside classes, to inside the corresponding classes as @staticmethods.
  As discussed, having these methods inside the classes allows py2hwsw_shell to import just the class.
  The user can view all the class's methods by typing `help(<class_name>)`.
- Improved iob_core docstrings in commit b28fc3136e4f8613e4a83dbefc49baff2b029ad0.
  Type `help(iob_core)` to view the new docstrings.