### PR TITLE
Example module that uses a bus

### DIFF
--- a/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
+++ b/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py
@@ -101,32 +101,22 @@ class iob_reg(iob_core):
             "ports": [
                 {
                     "name": "clk_en_rst_s",
-                    "wires": {
-                        "type": "iob_clk",
+                    "descr": "Clock, clock enable and reset port (bus with multiple wires)",
+                    "interface": {
+                        "kind": "iob_clk",
                         "params": clk_port_params,
                     },
-                    "descr": "Clock, clock enable and reset",
                 },
                 {
                     "name": "data_i",
-                    "descr": "Data input",
-                    "wires": [
-                        {
-                            "name": "data_i",
-                            "width": "DATA_W",
-                        },
-                    ],
+                    "descr": "Data input port (single wire)",
+                    "width": "DATA_W",
                 },
                 {
                     "name": "data_o",
-                    "descr": "Data output",
-                    "wires": [
-                        {
-                            "name": "data_o",
-                            "width": "DATA_W",
-                            "isvar": True,
-                        },
-                    ],
+                    "descr": "Data output port (single wire)",
+                    "width": "DATA_W",
+                    "isvar": True,
                 },
             ],
             "snippets": [


### PR DESCRIPTION
This PR uses iob_reg as an example, since it is a basic module that needs the `clk_en_rst` bus, and is a dependency for many other lib modules.

See `iob_reg` ports list for the most up-to-date example of a port/bus declaration using dictionaries: https://github.com/arturum1/py2hwsw/blob/bus_example/py2hwsw/lib/hardware/registers/iob_reg/iob_reg.py#L102-L120

(For now), this syntax is similar to the one in the 'Buses' codeshare.

Iob_reg currently has 3 ports:
- 'clk_en_rst_s' port (bus)
- 'data_i' port (wire)
- 'data_o' port (wire)

Example taken from PR https://github.com/IObundle/py2hwsw/pull/366