### PR TITLE
Fix main loop in `iob_v_tb.v`

### DIFF
--- a/py2hwsw/hardware/simulation/src/iob_v_tb.v
+++ b/py2hwsw/hardware/simulation/src/iob_v_tb.v
@@ -50,14 +50,14 @@ module iob_v_tb;
       $dumpfile("uut.vcd");
       $dumpvars();
 `endif
-      iob_valid_i  = 0;
-      iob_wdata_i  = 0;
-      iob_addr_i   = 0;
-      iob_wstrb_i  = 0;
+      iob_valid_i = 0;
+      iob_wdata_i = 0;
+      iob_addr_i  = 0;
+      iob_wstrb_i = 0;
 
-      clk          = 0;
-      cke          = 1;
-      arst         = 0;
+      clk         = 0;
+      cke         = 1;
+      arst        = 0;
       #10;
       arst = 1;
       #10;
@@ -114,7 +114,6 @@ module iob_v_tb;
          end else begin  // if (fscanf_ret == 5)
             $fclose(c2v_read_fp);
          end  // if (fscanf_ret != 5)
-         @(posedge clk);  //advance clock
       end  // while (1)
       $fclose(v2c_write_fp);
    end  // initial begin


### PR DESCRIPTION
Resolves https://github.com/IObundle/py2hwsw/issues/369

Main loop of iob_v_tb.v was advancing simulation, even when no requests were made (from iob_core_tb.c). This would allow simulation to advance in slow machines, skipping important control checkpoints.

This commit removes the time advance in the main loop when no requests are received.
Note: This means that the `iob_core_tb.c` must keep making requests in order for the simulation to advance. I'm not sure if this can be a problem for some testbenches.