### PR TITLE
Improve `_remove_duplicate_sources()` method. 

### DIFF
--- a/py2hwsw/lib/iob_system/hardware/fpga/quartus/iob_cyclonev_gt_dk/board.mk
+++ b/py2hwsw/lib/iob_system/hardware/fpga/quartus/iob_cyclonev_gt_dk/board.mk
@@ -7,7 +7,6 @@ BOARD_USER=$(CYC5_USER)
 BOARD_SERIAL_PORT=$(CYC5_SERIAL_PORT)
 
 VSRC+=$(FPGA_TOOL)/$(BOARD)/iob_reset_sync.v
-VSRC+=$(FPGA_TOOL)/$(BOARD)/iob_reg_a.v
 
 ifeq ($(USE_EXTMEM),1)
 VSRC+=$(FPGA_TOOL)/$(BOARD)/alt_ddr3.qsys

--- a/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_aes_ku040_db_g/board.tcl
+++ b/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_aes_ku040_db_g/board.tcl
@@ -88,7 +88,6 @@ if { $USE_EXTMEM > 0 } {
     read_verilog vivado/$BOARD/iob_xilinx_clock_wizard.v
     read_verilog vivado/$BOARD/iob_clock_wizard.v
     read_verilog vivado/$BOARD/iob_reset_sync.v
-    read_verilog vivado/$BOARD/iob_reg_a.v
 }
 
 if { $USE_ETHERNET > 0 } {

--- a/py2hwsw/scripts/iob_base.py
+++ b/py2hwsw/scripts/iob_base.py
@@ -663,3 +663,20 @@ def validate_verilog_const(value: str, direction: str):
         fail_with_msg(
             f"Invalid direction '{direction}' for wire '{value}'! Expected input or output."
         )
+
+
+def find_folder_by_name(root_dir, folder_name):
+    """
+    Searches for a folder by name within a given root directory.
+
+    Args:
+        root_dir (str): The directory to start the search from.
+        folder_name (str): The name of the folder to search for.
+
+    Returns:
+        str: The full path to the found folder, or None if not found.
+    """
+    for root, dirs, files in os.walk(root_dir):
+        if folder_name in dirs:
+            return os.path.join(root, folder_name)
+    return None


### PR DESCRIPTION
- Improve `_remove_duplicate_sources()` method.
  New method supports multiple levels of subfolders to check for and remove duplicate sources.
  This fixes failing ghactions tests in https://github.com/IObundle/iob-soc/pull/1025
- Remove 'iob_reg_a' from fpga dependencies.
  The 'iob_reg_a' module is no longer specific to the fpga boards. Now it is used by the base iob_system (in hardware/src/).