### PR TITLE
feat(verilator): update nix-shell verilator version

### DIFF
--- a/py2hwsw/hardware/simulation/verilator.mk
+++ b/py2hwsw/hardware/simulation/verilator.mk
@@ -82,7 +82,7 @@ cov-analyze: $(COV_RPT)
 	# --annotate-min <count>: set minimum threshold for toggle for sufficient coverage
 	# --annotate-all: write annotations for all modules, even if 100% covered
 	# more info: https://verilator.org/guide/latest/exe_verilator_coverage.html
-	verilator_coverage --annotate cov_annotated --annotate-min 2 --annotate-all $(COV_MERGE)
+	verilator_coverage --annotate cov_annotated --annotate-min 1 --annotate-all $(COV_MERGE)
 	$(CUSTOM_COVERAGE)
 
 clean: gen-clean

--- a/py2hwsw/lib/default.nix
+++ b/py2hwsw/lib/default.nix
@@ -12,7 +12,7 @@
 # bash-interactive-5.2p37
 # gnumake-4.4.1
 # iverilog-12.0
-# verilator-5.034
+# verilator (custom version v5.040)
 # gtkwave-3.3.121
 # python3-3.12.10
 # python3 black-25.1.0
@@ -78,6 +78,8 @@ let
 
   yosys = import ./scripts/yosys.nix { inherit pkgs; };
 
+  verilator_v5_040 = import ./scripts/verilator.nix { inherit pkgs; };
+
   pythonEnv = pkgs.python3.withPackages (ps: with ps; [
     black
     mypy
@@ -95,7 +97,6 @@ let
     bash
     gnumake
     verilog
-    verilator
     gtkwave
     python3
     pythonEnv
@@ -120,6 +121,7 @@ let
     in import "${volareSrc}" {
       inherit pkgs;
     })
+    verilator_v5_040
     yosys
     gcc
     libcap # Allows setting POSIX capabilities

--- a/py2hwsw/lib/peripherals/iob_uart/hardware/simulation/uart_coverage.waiver
+++ b/py2hwsw/lib/peripherals/iob_uart/hardware/simulation/uart_coverage.waiver
@@ -6,8 +6,6 @@
 
 // waiver structure:
 // waive filename:line[:line] [reason]
-waive iob_prio_enc.v:30:34 "Unused generate if branch"
-
 waive iob_universal_converter_iob_iob.v:21 "Some read data bits are unused/always 0"
 waive iob_universal_converter_iob_iob.v:29 "Some read data bits are unused/always 0"
 waive iob_universal_converter_iob_iob.v:39 "Some read data bits are unused/always 0"

--- a/py2hwsw/lib/scripts/verilator.nix
+++ b/py2hwsw/lib/scripts/verilator.nix
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 IObundle
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.stdenv.mkDerivation {
+  name = "verilator";
+  src = pkgs.fetchFromGitHub {
+    repo = "verilator";
+    owner = "verilator";
+    rev = "v5.040";
+    sha256 = "sha256-S+cDnKOTPjLw+sNmWL3+Ay6+UM8poMadkyPSGd3hgnc=";
+  };
+
+  # patch and postpatch, taken from:
+  # https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ve/verilator/package.nix
+  patches = [
+    (pkgs.fetchpatch {
+      name = "clang-V3hash-overload-fix.patch";
+      url = "https://github.com/verilator/verilator/commit/2aa260a03b67d3fe86bc64b8a59183f8dc21e117.patch";
+      hash = "sha256-waUsctWiAMG3lCpQi+VUUZ7qMw/kJGu/wNXPHZGuAoU=";
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs bin/* src/* nodist/* docs/bin/* examples/xml_py/* \
+    test_regress/{driver.py,t/*.{pl,pf}} \
+    test_regress/t/t_a1_first_cc.py \
+    test_regress/t/t_a2_first_sc.py \
+    ci/* ci/docker/run/* ci/docker/run/hooks/* ci/docker/buildenv/build.sh
+    # verilator --gdbbt uses /bin/echo to test if gdb works.
+    substituteInPlace bin/verilator --replace-fail "/bin/echo" "${pkgs.coreutils}/bin/echo"
+  '';
+
+  enableParallelBuilding = true;
+
+  # build + run dependencies
+  buildInputs = [ 
+     pkgs.perl
+     (pkgs.python3.withPackages (
+        pp: with pp; [
+            distro
+        ]
+     ))
+   ];
+  # build only dependencies
+  nativeBuildInputs = [
+     pkgs.makeWrapper
+     pkgs.flex
+     pkgs.bison
+     pkgs.autoconf
+     pkgs.help2man
+     pkgs.git
+  ];
+
+  nativeCheckInputs = [
+     pkgs.which
+     pkgs.coreutils
+     pkgs.python3
+     pkgs.numactl
+  ];
+
+  configurePhase = ''
+    autoconf
+    ./configure --prefix=$out
+  '';
+  buildPhase = "make -j$(nproc)";
+  installPhase = "make install";
+}


### PR DESCRIPTION
- update nix to use verilator v5.040 with more coverage fixes
- update annotation coverage threshold to 1: verilator v5.040 splits coverage between 0->1 and 1->0
- remove redundant uart coverage waiver: verilator v5.040 does not try to cover unused generate branches