### PR TITLE
Xcelium simulation fixes

### DIFF
--- a/py2hwsw/hardware/simulation/src/iob_v_tb.v
+++ b/py2hwsw/hardware/simulation/src/iob_v_tb.v
@@ -150,8 +150,10 @@ module iob_v_tb;
          #1 while (!iob_ready_o) #1;
 
          // Deassert one time step after the edge, so it doesn't race with the DUT's @(posedge clk)
-         @(posedge clk) #1 iob_valid_i = 0;
-         iob_wstrb_i = 0;
+         @(posedge clk) #1 begin
+            iob_valid_i = 0;
+            iob_wstrb_i = 0;
+         end
       end
    endtask
 

--- a/py2hwsw/hardware/simulation/src/iob_v_tb.v
+++ b/py2hwsw/hardware/simulation/src/iob_v_tb.v
@@ -150,10 +150,9 @@ module iob_v_tb;
          #1 while (!iob_ready_o) #1;
 
          // Deassert one time step after the edge, so it doesn't race with the DUT's @(posedge clk)
-         @(posedge clk) #1 begin
-            iob_valid_i = 0;
-            iob_wstrb_i = 0;
-         end
+         @(posedge clk) #1 iob_valid_i = 0;
+         iob_wstrb_i = 0;
+         
       end
    endtask
 

--- a/py2hwsw/hardware/simulation/src/iob_v_tb.v
+++ b/py2hwsw/hardware/simulation/src/iob_v_tb.v
@@ -149,7 +149,8 @@ module iob_v_tb;
 
          #1 while (!iob_ready_o) #1;
 
-         @(posedge clk) iob_valid_i = 0;
+         // Deassert one time step after the edge, so it doesn't race with the DUT's @(posedge clk)
+         @(posedge clk) #1 iob_valid_i = 0;
          iob_wstrb_i = 0;
       end
    endtask

--- a/py2hwsw/hardware/simulation/xcelium.mk
+++ b/py2hwsw/hardware/simulation/xcelium.mk
@@ -80,7 +80,7 @@ endif
 
 clean: gen-clean
 	@rm -rf xmelab.log  xmsim.log  xmvlog.log xcelium.d 
-	@rm -f iob_cov_waiver.vRefine
+	@rm -f iob_cov_waiver.vRefine xmsim_run.tcl
 
 very-clean: clean
 	@rm -rf cov_work *.log

--- a/py2hwsw/hardware/simulation/xcelium.mk
+++ b/py2hwsw/hardware/simulation/xcelium.mk
@@ -69,7 +69,8 @@ exec: comp
 ifeq ($(TBTYPE),UVM)
 	sync && sleep 2 && xrun -R $(SFLAGS) -sv_lib worklib.iob_uvm_tb:sv +UVM_TESTNAME=iob_test
 else
-	sync && sleep 2 && xmsim $(SFLAGS) $(COV_SFLAGS) worklib.$(TB):v
+	printf 'run\nexit\n' > xmsim_run.tcl
+	sync && sleep 2 && xmsim $(SFLAGS) $(COV_SFLAGS) -input xmsim_run.tcl worklib.$(TB):v
 endif
 ifeq ($(COV),1)
 	ls -d cov_work/scope/* > all_ucd_file


### PR DESCRIPTION
### 1. Remove the `iob_write` deassertion race

In `hardware/simulation/src/iob_v_tb.v`, `iob_write` previously cleared `iob_valid_i` and `iob_wstrb_i` directly on the rising clock edge.

This created a simulation scheduling race with the DUT processes sampling the transaction on the same edge, which could cause writes to be missed under Xcelium.

The signals are now deasserted one simulation time step after the edge, matching the existing `iob_read` behaviour:

```verilog
@(posedge clk) #1 iob_valid_i = 0;
iob_wstrb_i = 0;
```

### 2. Run non-UVM Xcelium simulations in batch mode

In `hardware/simulation/xcelium.mk`, the non-UVM target now creates an Xcelium command file containing:

```tcl
run
exit
```

and passes it to `xmsim` using `-input`.

This ensures that the simulation is executed and that the `xmsim` process terminates after the run completes, instead of potentially remaining at the interactive `xcelium>` prompt and preventing `make` from returning.

```make
printf 'run\nexit\n' > xmsim_run.tcl
xmsim $(SFLAGS) $(COV_SFLAGS) -input xmsim_run.tcl worklib.$(TB):v
```
