### PR TITLE
PLIC/CLINT knob + csrs fix + zcu040 support

### DIFF
--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
@@ -341,7 +341,7 @@ class csr_gen:
             else:
                 lines += f"    assign {name}_addressed = {int_addr_stable_cmp} (internal_iob_addr_stable < ({addr}+(2**({addr_w}))));\n"
 
-            lines += f"   assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed & write_en;\n"
+            lines += f"   assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed;\n"
             if type(log2n_items) is not int or log2n_items > 0:
                 lines += f"   assign {name}_addr{suffix} = internal_iob_addr_stable - {addr};\n"
             wires.append(
@@ -473,7 +473,7 @@ class csr_gen:
                     lines += f"    assign {name}_addressed = (internal_iob_addr_stable >= ({addr})) && (internal_iob_addr_stable < ({addr}+(2**({addr_w}))));\n"
 
                 # Create new valid and addr signals
-                lines += f"   assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed;\n"
+                lines += f"   assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed & ~write_en;\n"
                 if type(log2n_items) is not int or log2n_items > 0:
                     lines += f"   assign {name}_addr{suffix} = internal_iob_addr_stable - {addr};\n"
 

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
@@ -473,7 +473,7 @@ class csr_gen:
                     lines += f"    assign {name}_addressed = (internal_iob_addr_stable >= ({addr})) && (internal_iob_addr_stable < ({addr}+(2**({addr_w}))));\n"
 
                 # Create new valid and addr signals
-                lines += f"   assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed & ~write_en;\n"
+                lines += f"   assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed;\n"
                 if type(log2n_items) is not int or log2n_items > 0:
                     lines += f"   assign {name}_addr{suffix} = internal_iob_addr_stable - {addr};\n"
 

--- a/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
+++ b/py2hwsw/lib/hardware/iob_csrs/scripts/csr_gen.py
@@ -341,7 +341,7 @@ class csr_gen:
             else:
                 lines += f"    assign {name}_addressed = {int_addr_stable_cmp} (internal_iob_addr_stable < ({addr}+(2**({addr_w}))));\n"
 
-            lines += f"   assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed;\n"
+            lines += f"   assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed & write_en;\n"
             if type(log2n_items) is not int or log2n_items > 0:
                 lines += f"   assign {name}_addr{suffix} = internal_iob_addr_stable - {addr};\n"
             wires.append(

--- a/py2hwsw/lib/iob_system/iob_system.py
+++ b/py2hwsw/lib/iob_system/iob_system.py
@@ -992,7 +992,7 @@ def setup(py_params: dict):
     # riscv_interrupts/riscv_timebase composite wires. When PLIC or CLINT is
     # disabled, the signals that peripheral used to drive are left floating, so
     # tie them off to 0 here.
-    if params["cpu"] != "none" and params["use_peripherals"]:
+    if params["cpu"] != "none" and params["use_peripherals"] and params["include_snippet"]:
         tie_off_code = ""
         if not params["use_plic"]:
             tie_off_code += """

--- a/py2hwsw/lib/iob_system/iob_system.py
+++ b/py2hwsw/lib/iob_system/iob_system.py
@@ -28,6 +28,14 @@ def setup(py_params: dict):
             False,
             "If should include ethernet peripheral, MII interface, and testbenches with ethernet support.",
         ),
+        "use_plic": (
+            True,
+            "If should instantiate the PLIC peripheral and wire its outputs (meip/seip) to the CPU's interrupt_i port. Set to False for CPUs with no external-interrupt input wired.",
+        ),
+        "use_clint": (
+            True,
+            "If should instantiate the CLINT peripheral and wire its outputs (msip/mtip, mtime) to the CPU's interrupt_i/timebase_i ports. Set to False for CPUs with no timer/software-interrupt input wired.",
+        ),
         "addr_w": (32, "CPU address width"),
         "data_w": (32, "CPU data width"),
         "mem_addr_w": (
@@ -560,35 +568,41 @@ def setup(py_params: dict):
                 },
             },
             # Peripheral cbus wires added automatically
-            {
-                "name": "plic_interrupts",
-                "descr": "Connect PLIC interrupts to CPU",
-                "signals": [
-                    {"name": "riscv_meip"},
-                    {"name": "riscv_seip"},
-                ],
-            },
-            {
-                "name": "clint_rt_clk",
-                "descr": "CLINT real time clock",
-                "signals": [
-                    {
-                        "name": "rt_clk",
-                        "descr": "Real Time clock input if available (usually 32.768 kHz)",
-                        "width": "1",
-                    },
-                ],
-            },
-            {
-                "name": "clint_interrupts",
-                "descr": "Connect CLINT interrupts to CPU",
-                "signals": [
-                    {"name": "riscv_mtip"},
-                    {"name": "riscv_msip"},
-                ],
-            },
             # NOTE: Add other peripheral wires here
         ]
+        if params["use_plic"]:
+            attributes_dict["wires"] += [
+                {
+                    "name": "plic_interrupts",
+                    "descr": "Connect PLIC interrupts to CPU",
+                    "signals": [
+                        {"name": "riscv_meip"},
+                        {"name": "riscv_seip"},
+                    ],
+                },
+            ]
+        if params["use_clint"]:
+            attributes_dict["wires"] += [
+                {
+                    "name": "clint_rt_clk",
+                    "descr": "CLINT real time clock",
+                    "signals": [
+                        {
+                            "name": "rt_clk",
+                            "descr": "Real Time clock input if available (usually 32.768 kHz)",
+                            "width": "1",
+                        },
+                    ],
+                },
+                {
+                    "name": "clint_interrupts",
+                    "descr": "Connect CLINT interrupts to CPU",
+                    "signals": [
+                        {"name": "riscv_mtip"},
+                        {"name": "riscv_msip"},
+                    ],
+                },
+            ]
         if params["use_ethernet"]:
             attributes_dict["wires"] += [
                 {
@@ -853,36 +867,42 @@ def setup(py_params: dict):
                 },
                 "plic_source_id": 1,
             },
-            {
-                "core_name": "iob_plic",
-                "instance_name": "PLIC0",
-                "instance_description": "RISC-V PLIC peripheral",
-                "is_peripheral": True,
-                "connect": {
-                    "clk_en_rst_s": "clk_en_rst_s",
-                    # Cbus connected automatically
-                    "interrupt_i": "interrupts",
-                    "interrupt_o": "plic_interrupts",
-                },
-            },
-            {
-                "core_name": "iob_clint",
-                "instance_name": "CLINT0",
-                "instance_description": "RISC-V CLINT peripheral",
-                "is_peripheral": True,
-                "parameters": {
-                    "N_CORES": 1,
-                },
-                "connect": {
-                    "clk_en_rst_s": "clk_en_rst_s",
-                    # Cbus connected automatically
-                    "rt_clk_i": "clint_rt_clk",
-                    "interrupt_o": "clint_interrupts",
-                    "timebase_o": "riscv_timebase",
-                },
-            },
             # NOTE: Instantiate other peripherals here, using the 'is_peripheral' flag
         ]
+        if params["use_plic"]:
+            attributes_dict["subblocks"] += [
+                {
+                    "core_name": "iob_plic",
+                    "instance_name": "PLIC0",
+                    "instance_description": "RISC-V PLIC peripheral",
+                    "is_peripheral": True,
+                    "connect": {
+                        "clk_en_rst_s": "clk_en_rst_s",
+                        # Cbus connected automatically
+                        "interrupt_i": "interrupts",
+                        "interrupt_o": "plic_interrupts",
+                    },
+                },
+            ]
+        if params["use_clint"]:
+            attributes_dict["subblocks"] += [
+                {
+                    "core_name": "iob_clint",
+                    "instance_name": "CLINT0",
+                    "instance_description": "RISC-V CLINT peripheral",
+                    "is_peripheral": True,
+                    "parameters": {
+                        "N_CORES": 1,
+                    },
+                    "connect": {
+                        "clk_en_rst_s": "clk_en_rst_s",
+                        # Cbus connected automatically
+                        "rt_clk_i": "clint_rt_clk",
+                        "interrupt_o": "clint_interrupts",
+                        "timebase_o": "riscv_timebase",
+                    },
+                },
+            ]
         if params["use_ethernet"]:
             attributes_dict["subblocks"] += [
                 {
@@ -967,6 +987,24 @@ def setup(py_params: dict):
 """
             }
         ]
+
+    # The CPU's interrupt_i/timebase_i ports are always connected to the
+    # riscv_interrupts/riscv_timebase composite wires. When PLIC or CLINT is
+    # disabled, the signals that peripheral used to drive are left floating, so
+    # tie them off to 0 here.
+    if params["cpu"] != "none" and params["use_peripherals"]:
+        tie_off_code = ""
+        if not params["use_plic"]:
+            tie_off_code += """
+   assign riscv_meip = 1'b0;
+   assign riscv_seip = 1'b0;"""
+        if not params["use_clint"]:
+            tie_off_code += """
+   assign riscv_mtip = 1'b0;
+   assign riscv_msip = 1'b0;
+   assign riscv_mtime = 64'b0;"""
+        if tie_off_code:
+            attributes_dict["snippets"] += [{"verilog_code": tie_off_code + "\n"}]
 
     iob_system_scripts(attributes_dict, params, py_params)
 

--- a/py2hwsw/lib/iob_system/scripts/iob_system_utils.py
+++ b/py2hwsw/lib/iob_system/scripts/iob_system_utils.py
@@ -97,6 +97,7 @@ def append_board_wrappers(attributes_dict, params):
         "iob_zybo_z7": "vivado",
         "iob_smart_zynq_sl": "vivado",
         "iob_basys3": "vivado",
+        "iob_zcu104": "vivado",
     }
     for board in attributes_dict.get("board_list", []):
         tool = tools[board]


### PR DESCRIPTION
### 1. (`csr_gen.py`) bug (minor fix)
The _csr_gen.py_ register generator is currently asymmetric between read and write registers.
A READ register correctly refuses to fire its valid on a write (`& ~write_en`). By symmetry a WRITE register should refuse to fire its valid on a read (`& write_en`). That gate was missing. 

(`iob_wstrb_o`) currently gates writes, which can make this fix redundant. Still, it's good practice to keep read and write registers symmetrical, and give the write valid an extra security layer.


Read Valid:
```verilog
assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed & ~write_en;
```

Write Valid:
```verilog
assign {name}_valid{suffix} = internal_iob_valid & {name}_addressed;
```

### 2. Add ZCU104 board to (`append_board_wrappers()`)

As per the current FIXME statement in (`iob_system_utils.py`):
```python
# FIXME: We should have a way for child cores to specify their board's tool (assuming child cores may add new unknown boards)
```

There is no current way to add a board wrapper through a child core's .py file. The current (`iob-hyperram-controller`) is being developed for the zcu104 board, that contains the apropriate pinout for an HyperRAM memory.

This allows users to implement (`hardware/fpga/vivado/iob_zcu104`) without Py2HWSW errors


### 3. Make PLIC/CLINT optional
Currently, Py2HWSW forces users to instantiate PLIC/CLINT hardware. If those were unwanted, the core still had to instantiate the ports and left them unwired. Nonetheless, extra hardware were always used.

This fix mirrors the (`use_ethernet`) implementation, adding (`use_plic`)  and (`use_clint`), allowing the user to select PLIC/CLINT usage separately.
