### PR TITLE
Added non-blocking assign to iobuf

### DIFF
--- a/py2hwsw/lib/hardware/iob_iobuf/iob_iobuf.py
+++ b/py2hwsw/lib/hardware/iob_iobuf/iob_iobuf.py
@@ -91,7 +91,7 @@ def setup(py_params_dict):
       end else begin : tool_other
          reg o_var;
          assign io_io = t_i ? 1'bz : i_i;
-         always @* o_var = #1 io_io;
+         always @* o_var <= #1 io_io;
          assign o_int = o_var;
       end
    endgenerate


### PR DESCRIPTION
In `py2hwsw/py2hwsw/lib/hardware/iob_iobuf/iob_iobuf.py`, `o_var` is assigned to `io_io` with one time unit of delay.

The current implementation uses "=", which blocks listening to during that time unit:
```verilog
always @* o_var = #1 io_io;
```
After `io_io` changes, `always@*` catches that variation and suspends itself during `#1`.  After `#1`, `o_var` is assigned with t hat value of `io_io`. The problem is that, if `io_io` varies within that time unit, `o_var` will not detect those variations.

The suggestion is using "<=":

```verilog
always @* o_var <= #1 io_io;
```

"<=" schedules the variations. Which means all variations of `io_io` will reach `o_var` with the same ONE (`#1`) delay.