### PR TITLE
BREAKING: Upgrade board_client.py and board_server.py to support multiple shared boards on the same server.

### DIFF
--- a/py2hwsw/hardware/fpga/Makefile
+++ b/py2hwsw/hardware/fpga/Makefile
@@ -78,7 +78,7 @@ CONSOLE_CMD ?=$(PYTHON_DIR)/console.py -s $(BOARD_SERIAL_PORT)
 
 #board client command
 GRAB_TIMEOUT ?= 300
-BOARD_GRAB_CMD=../../scripts/board_client.py grab $(GRAB_TIMEOUT)
+BOARD_GRAB_CMD=../../scripts/board_client.py grab $(GRAB_TIMEOUT) -b $(BOARD)
 
 #run fpga image
 run: build $(RUN_DEPS)

--- a/py2hwsw/scripts/board_client.py
+++ b/py2hwsw/scripts/board_client.py
@@ -25,64 +25,55 @@ else:
 
 DEBUG = False
 
-# Define the client's IP, port and version
-# Must match the server's
-HOST = "localhost"  # Use the loopback interface
-PORT = 50007  # Use the same port as the server
-VERSION = "V0.2"
+HOST = "localhost"
+PORT = 50007
+VERSION = "V0.3"
 
-# user and duration board is needed
 USER = os.environ["USER"]
-DURATION = "15"  # Default duration is 5 seconds
+DURATION = "15"
 
-# List of processes to kill when terminating board_client
 proc_list: List = []
-
-# Variables to store the commands to run
 console_command = None
 fpga_prog_command = None
 simulator_run_command = None
 
-# Prefix for print messages
 CPREFIX = "[board_client]: "
+BOARD = None
 
 
-# Print usage and exit
 def perror():
     print(
         f"""
-Usage: ./{sys.argv[0]} [grab [duration in seconds] -c [console launch command] [-p [fpga program command] | -s [simulator run command]] | release]
+Usage: ./{sys.argv[0]} [grab [duration] | release] -b BOARD [-c console_cmd] [-p prog_cmd | -s sim_cmd]
+    -b, --board BOARD          Board name (required for 'grab' and 'release').
+    -c, --console CMD          Command to launch the console.
+    -p, --program CMD          Command to program the FPGA.
+    -s, --simulate CMD         Command to run the simulator.
     If -p is given then -c is required. If -s is given then -c is optional.
-    On fpga program (-p) mode, it will launch the fpga program command first, wait for it to finish, and then launch the console command.
-        In this mode, it will try to contact the `board_server` first to reserve/grab the board to avoid collisions on shared machines/boards.
-        If the `board_server` is not available, it prints a warning and runs normally.
-    On simulator run (-s) mode, it will run the simulator command and the console command in parallel.
-        In this mode, the grab duration specifies the timeout for the simulation. The `board_server` is not used in simulation mode.
+    On fpga program (-p) mode, it contacts the server to grab the board, runs the program
+        command, then launches the console.
+    On simulator run (-s) mode, grab duration is the simulation timeout; server is not used.
 """
     )
     sys.exit(1)
 
 
-# Function to form a request
 def form_request(command):
     request = ""
     if command == "grab":
-        request += f"{command} {USER} {DURATION} {VERSION}"
+        request += f"{command} {BOARD} {USER} {DURATION} {VERSION}"
     elif command == "release":
-        request += f"{command} {USER} {VERSION}"
+        request += f"{command} {BOARD} {USER} {VERSION}"
     elif command == "query":
         request += f"{command} {VERSION}"
     return request
 
 
-# Function to send the request
 def send_request(request):
     while True:
-        # Create a socket
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(10)
 
-        # Connect with the server
         try:
             s.connect((HOST, PORT))
         except Exception:
@@ -91,15 +82,12 @@ def send_request(request):
             )
             return
 
-        # Send the request to the server
         s.sendall(request.encode("utf-8"))
 
-        # Receive the response from the server
         response = s.recv(1024).decode()
         s.close()
         print(CPREFIX + "Server response: " + response)
 
-        # Process the response
         if "ERROR" in response:
             sys.exit(1)
 
@@ -115,46 +103,34 @@ def send_request(request):
             break
 
 
-# Function to send a request to release the board
 def release_board(signal=None, frame=None):
     request = form_request("release")
     send_request(request)
 
 
-# Exit the program and release the board if -p is given
 def exit_program(exit_code):
-    # Release the board if -p is given
     if fpga_prog_command:
         release_board()
-
     sys.exit(exit_code)
 
 
-# Function to kill all processes from proc_list and exit with error.
 def kill_processes(sig=None, frame=None):
     for proc in proc_list:
-        # Check if process is still running
         if proc.poll() is None:
-            # Gracefully terminate process group (the process and its children)
             os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
             try:
-                # Wait for process to terminate gracefully
                 proc.wait(2)
             except subprocess.TimeoutExpired:
                 print(
                     "Timeout waiting for process to terminate gracefully! Forcing process kill..."
                 )
-                # Process did not terminate gracefully, kill it
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-    # Dont throw an error if the function is called from signal handler
     if sig is None:
         exit_program(1)
     else:
         exit_program(0)
 
 
-# Function to wait for a process to finish
-# If the process times out, kill all other processes
 def proc_wait(proc, timeout):
     try:
         proc.wait(timeout=timeout)
@@ -172,7 +148,6 @@ if __name__ == "__main__":
         epilog="If -p is given then -c is required. If -s is given then -c is optional.",
     )
 
-    # Add command argument with default value
     parser.add_argument(
         "command",
         nargs="?",
@@ -180,7 +155,6 @@ if __name__ == "__main__":
         help='Command to send to server. Can be "grab", "release" or "query".',
     )
 
-    # Add optional duration argument only available if command=grab
     parser.add_argument(
         "duration",
         nargs="?",
@@ -188,12 +162,10 @@ if __name__ == "__main__":
         help="Duration in seconds to grab the board.",
     )
 
-    # Add -c argument
     parser.add_argument(
         "-c", "--console", default=None, help="Command to launch the console."
     )
 
-    # Add -p argument
     parser.add_argument(
         "-p",
         "--program",
@@ -201,7 +173,6 @@ if __name__ == "__main__":
         help="Command to program the FPGA. Cannot be used with `-s` argument. Requires `-c` argument aswell.",
     )
 
-    # Add -s argument
     parser.add_argument(
         "-s",
         "--simulate",
@@ -209,19 +180,36 @@ if __name__ == "__main__":
         help="Command to run the simulator. Cannot be used with `-p` argument.",
     )
 
-    # Assign arguments to variables
-    command = parser.parse_args().command
-    DURATION = parser.parse_args().duration
-    console_command = parser.parse_args().console
-    fpga_prog_command = parser.parse_args().program
-    simulator_run_command = parser.parse_args().simulate
+    parser.add_argument(
+        "-b",
+        "--board",
+        default=None,
+        help="Board name to grab/release/query (required for grab and release).",
+    )
 
-    # Ensure either `-p` or `-s` is given with grab command, to either program fpga or run simulation, respectively.
+    args = parser.parse_args()
+    command = args.command
+    DURATION = args.duration
+    console_command = args.console
+    fpga_prog_command = args.program
+    simulator_run_command = args.simulate
+    BOARD = args.board
+
+    if command == "grab" and not args.board and fpga_prog_command:
+        print(
+            f"{iob_colors.FAIL}Error: argument `-b`/`--board` is required for FPGA grab.{iob_colors.ENDC}"
+        )
+        sys.exit(1)
+    if command == "release" and not args.board:
+        print(
+            f"{iob_colors.FAIL}Error: argument `-b`/`--board` is required for 'release' command.{iob_colors.ENDC}"
+        )
+        sys.exit(1)
+
     assert command != "grab" or bool(fpga_prog_command) != bool(
         simulator_run_command
     ), f"{iob_colors.FAIL}Either `-p` or `-s` must be present with 'grab' command. (Cannot be both){iob_colors.ENDC}"
 
-    # Ensure `-c` is given for `-p`
     assert (
         not fpga_prog_command or console_command
     ), f"{iob_colors.FAIL}Argument `-c` must be present with `-p`.{iob_colors.ENDC}"
@@ -232,22 +220,15 @@ if __name__ == "__main__":
             f'{CPREFIX}{iob_colors.OKBLUE}DEBUG: Request is "{request}"{iob_colors.ENDC}'
         )
 
-    # Don't send request for "grab" command in simulation mode
-    # User may still want to send release or query commands without fpga command.
     if command != "grab" or fpga_prog_command:
         send_request(request)
 
     if command == "grab":
-        # Call `kill_processes()` when termination signals are received
         signal.signal(signal.SIGINT, kill_processes)
         signal.signal(signal.SIGTERM, kill_processes)
     else:
-        # End program if command is not "grab"
         sys.exit(0)
 
-    # Lines below will only run if command=="grab" and request successful
-
-    # Launch simulator in the background if -s was given
     if simulator_run_command:
         print(f"{CPREFIX}{iob_colors.INFO}Running simulator{iob_colors.ENDC}")
         sim_proc = subprocess.Popen(
@@ -257,13 +238,10 @@ if __name__ == "__main__":
             shell=True,
             start_new_session=True,
         )
-        # Add the simulator process to the list of processes to kill
         proc_list.append(sim_proc)
 
-    # Start counting time since start of FPGA programming
     start_time = time.time()
 
-    # Program the FPGA if -p is given and wait
     if fpga_prog_command:
         print(f"{CPREFIX}{iob_colors.INFO}Programming FPGA{iob_colors.ENDC}")
         fpga_prog_proc = subprocess.Popen(
@@ -281,12 +259,9 @@ if __name__ == "__main__":
             )
             kill_processes()
 
-    # Update time passed
     remaining_duration = int(DURATION) - (time.time() - start_time)
 
-    # Run console if -c is given and wait
     if console_command:
-        # Run console and wait for completion/timeout.
         print(f"{CPREFIX}{iob_colors.INFO}Running console{iob_colors.ENDC}")
         console_proc = subprocess.Popen(
             console_command,
@@ -303,10 +278,8 @@ if __name__ == "__main__":
             )
             kill_processes()
 
-        # Update time passed
         remaining_duration = int(DURATION) - (time.time() - start_time)
 
-    # Wait for simulator to finish
     if simulator_run_command:
         print(
             f"{CPREFIX}{iob_colors.INFO}Waiting for simulator to finish{iob_colors.ENDC}"

--- a/py2hwsw/scripts/board_server.py
+++ b/py2hwsw/scripts/board_server.py
@@ -10,88 +10,97 @@ import socket
 
 DEBUG = False
 
+HOST = "localhost"
+PORT = 50007
+VERSION = "V0.3"
 
-# This is a simple server that will listen for connections on port 50007 from clients that want to use an FPGA board.
-# To install and run this server, do the following:
-# 1. Install Python 3.6 or later, and move to the lib directory
-#         > cd py2hwsw/lib
-#
-# 2. Run the following command from the root of this repository:
-#         > sudo make board_server_install
-#
-# To uninstall the server, run:
-#        > sudo make board_server_uninstall
-#
-# To check if the server is running, run:
-#        > sudo make board_server_status
-
-# Define the server's IP, port, and version
-# Must match the client's IP and port
-
-HOST = "localhost"  # Listen on all available interfaces
-PORT = 50007  # Use a non-privileged port
-VERSION = "V0.2"
-
-# user and duration board are needed
-USER = ""
-DURATION = "300"  # 5 minutes
-
-# Init board status
-board_status = "idle"
+# Dynamically tracks boards as clients grab them.
+# board_name -> {"user": str, "grab_time": float, "duration": str}
+boards = {}
 
 
-def get_remaining_time():
-    global DURATION
-    return str(int(DURATION) - (time.time() - grab_time))
+def get_remaining_time(grab_time, duration):
+    return int(duration) - (time.time() - grab_time)
 
 
 def get_response(request):
-    global board_status
-    global grab_time
-    global USER
-    global DURATION
+    global boards
 
-    # check client's version
     if VERSION not in request:
         return "ERROR: Wrong version"
 
-    if get_remaining_time() <= "0.1":
-        board_status = "idle"
-        USER = ""
+    # Clean up expired grabs
+    now = time.time()
+    expired = [
+        b
+        for b in list(boards.keys())
+        if int(boards[b]["duration"]) - (now - boards[b]["grab_time"]) <= 0.1
+    ]
+    for b in expired:
         if DEBUG:
-            print("Board released due to timeout")
+            print(f"Board {b} released due to timeout")
+        del boards[b]
 
-    if request.startswith("query"):
-        if board_status == "idle":
-            response = "Board is idle"
-        else:
-            time_remaining = get_remaining_time()
-            response = f"Board is grabbed by user {USER} for {time_remaining} seconds"
+    parts = request.split()
+    command = parts[0]
 
-    elif request.startswith("grab"):
-        if board_status == "idle":
-            board_status = "grabbed"
-            grab_time = time.time()
-            USER = request.split()[1]
-            DURATION = request.split()[2]
-            response = f"Success: board grabbed by {USER} for {DURATION} seconds."
-        else:
-            time_remaining = get_remaining_time()
-            response = f"Failure: board grabbed by {USER} for {time_remaining} seconds."
-
-    elif request.startswith("release"):
-        if board_status == "idle":
-            response = "ERROR: board already idle."
-        elif board_status == "grabbed":
-            requesting_user = request.split()[1]
-            if requesting_user == USER:
-                board_status = "idle"
-                USER = ""
-                response = "Success: board released."
+    if command == "query":
+        if len(parts) >= 3:
+            # query BOARD VERSION
+            board = parts[1]
+            if board in boards:
+                b = boards[board]
+                time_remaining = get_remaining_time(b["grab_time"], b["duration"])
+                response = f"Board {board} is grabbed by user {b['user']} for {time_remaining} seconds"
             else:
-                response = (
-                    f"ERROR: cannot release board in use by another user ({USER})"
-                )
+                response = f"Board {board} is idle"
+        else:
+            # query VERSION -> report all tracked boards
+            if not boards:
+                response = "All boards are idle"
+            else:
+                board_strs = []
+                for b, info in boards.items():
+                    time_remaining = get_remaining_time(
+                        info["grab_time"], info["duration"]
+                    )
+                    board_strs.append(
+                        f"Board {b} grabbed by {info['user']} for {time_remaining}s"
+                    )
+                response = " | ".join(board_strs)
+
+    elif command == "grab":
+        # grab BOARD USER DURATION VERSION
+        board = parts[1]
+        user = parts[2]
+        duration = parts[3]
+
+        if board not in boards:
+            boards[board] = {
+                "user": user,
+                "grab_time": time.time(),
+                "duration": duration,
+            }
+            response = (
+                f"Success: board {board} grabbed by {user} for {duration} seconds."
+            )
+        else:
+            b = boards[board]
+            time_remaining = get_remaining_time(b["grab_time"], b["duration"])
+            response = f"Failure: board {board} grabbed by {b['user']} for {time_remaining} seconds."
+
+    elif command == "release":
+        # release BOARD USER VERSION
+        board = parts[1]
+        requesting_user = parts[2]
+
+        if board not in boards:
+            response = f"ERROR: board {board} already idle."
+        elif requesting_user == boards[board]["user"]:
+            del boards[board]
+            response = f"Success: board {board} released."
+        else:
+            response = f"ERROR: cannot release board {board} in use by another user ({boards[board]['user']})"
 
     if DEBUG:
         print(f'Returning response: "{response}"')
@@ -99,20 +108,16 @@ def get_response(request):
 
 
 if __name__ == "__main__":
-    grab_time = time.time()
-
-    # Create a TCP/IP socket
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind((HOST, PORT))
     s.listen()
 
-    # Loop forever
     while True:
         conn, addr = s.accept()
         request = conn.recv(1024).decode("utf-8")
         if DEBUG:
             print(f"Received request: {request}")
-            response = get_response(request)
+        response = get_response(request)
         if DEBUG:
             print(f"Got response: {response}")
-            conn.sendall(response.encode("utf-8"))
+        conn.sendall(response.encode("utf-8"))


### PR DESCRIPTION
- board_server.py: drop single-board globals, dynamically track any board name clients request; clean up expired grabs automatically
- board_client.py: add -b/--board argument (required for FPGA grab and release, optional for simulator/query)
- Bump protocol version to V0.3 — old V0.2 clients are rejected (breaking)
- Fix server bug where response was nested inside the DEBUG guard

Callers must now pass -b <board_name> for FPGA grabs and releases. Simulator mode (-s) does not contact the server and does not require -b.

Usage examples
```
board_client.py query
board_client.py query -b board0

board_client.py grab 300 -b iob_zybo_z7 -p "make prog" -c "./console.py"

board_client.py grab 120 -s "make sim" -c "./console.py"

board_client.py release -b iob_zybo_z7
```