### PR TITLE
Fix Verilator lint warnings in iob_iobuf.py

### DIFF
--- a/py2hwsw/lib/hardware/iob_iobuf/iob_iobuf.py
+++ b/py2hwsw/lib/hardware/iob_iobuf/iob_iobuf.py
@@ -91,7 +91,9 @@ def setup(py_params_dict):
       end else begin : tool_other
          reg o_var;
          assign io_io = t_i ? 1'bz : i_i;
+         /* verilator lint_off COMBDLY */
          always @* o_var <= #1 io_io;
+         /* verilator lint_on COMBDLY */
          assign o_int = o_var;
       end
    endgenerate


### PR DESCRIPTION
Supresses Verilator warning introduced by changes from PR: https://github.com/IObundle/py2hwsw/pull/439#issuecomment-5186478673

The iob_iobuf module still works in Verilator, as it continues to use blocking assignment '=', as it did before PR #439.