### PR TITLE
Use standard `buf` primitive for feedback delay in `iob_iobuf`

### DIFF
--- a/py2hwsw/lib/hardware/iob_iobuf/iob_iobuf.py
+++ b/py2hwsw/lib/hardware/iob_iobuf/iob_iobuf.py
@@ -90,11 +90,13 @@ def setup(py_params_dict):
          );
       end else begin : tool_other
          reg o_var;
+
          assign io_io = t_i ? 1'bz : i_i;
-         /* verilator lint_off COMBDLY */
-         always @* o_var <= #1 io_io;
-         /* verilator lint_on COMBDLY */
-         assign o_int = o_var;
+
+         // Buffer gate primitive to add inertial delay. Models physical pad propagation time and prevents
+         // infinite zero-delay combinational feedback loops in event-driven simulators.
+         // Ignored by synthesis tools.
+         buf #1 u_pad_delay (o_int, io_io);
       end
    endgenerate
 

--- a/py2hwsw/lib/hardware/iob_iobuf/iob_iobuf.py
+++ b/py2hwsw/lib/hardware/iob_iobuf/iob_iobuf.py
@@ -89,13 +89,12 @@ def setup(py_params_dict):
             .IO(io_io)
          );
       end else begin : tool_other
-         reg o_var;
 
          assign io_io = t_i ? 1'bz : i_i;
 
-         // Buffer gate primitive to add inertial delay. Models physical pad propagation time and prevents
-         // infinite zero-delay combinational feedback loops in event-driven simulators.
-         // Ignored by synthesis tools.
+         // Buffer gate primitive to add inertial delay. Models physical pad propagation
+         // time and prevents infinite zero-delay combinational feedback loops in
+         // event-driven simulators. Ignored by synthesis tools.
          buf #1 u_pad_delay (o_int, io_io);
       end
    endgenerate


### PR DESCRIPTION
Related to PR https://github.com/IObundle/py2hwsw/pull/439

### Summary
Replaced procedural non-blocking assignment (`<=`) inside `always @*` with a standard Verilog `buf` primitive to model pad feedback delay in the `iob_iobuf` module. 

### Motivation
* Prevents zero-delay combinational feedback loops/oscillations during event-driven simulation.
* Eliminates linter and Verilator warnings (`BLKANDNBLK`) caused by using `<=` inside combinational blocks.
* Bypasses open-source simulator limitations (e.g., Icarus Verilog handling of net delays on tristate drivers).

### Testing
* Validated on **Icarus Verilog**, **Verilator**, and **XSim** using `iob_system_linux`. 
* Runs clean without compilation or simulation warnings.
* *Note: The `inout` signal was undriven in this test run; further testbench scenarios driving active data across the pad are recommended.*