### PR TITLE
Add ethernet support for Smart Zynq SL FPGA board

### DIFF
--- a/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_smart_zynq_sl/board.tcl
+++ b/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_smart_zynq_sl/board.tcl
@@ -82,6 +82,7 @@ if { $USE_EXTMEM > 0 } {
 if { $USE_ETHERNET > 0 } {
     read_verilog vivado/$BOARD/iob_xilinx_ibufg.v
     read_verilog vivado/$BOARD/iob_xilinx_oddr.v
+    read_verilog vivado/$BOARD/iob_xilinx_iddr.v
 
     if {[file exists "vivado/$BOARD/iob_eth_dev.sdc"]} {
         read_xdc vivado/$BOARD/iob_eth_dev.sdc

--- a/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_smart_zynq_sl/iob_system_iob_smart_zynq_sl/iob_system_iob_smart_zynq_sl.py
+++ b/py2hwsw/lib/iob_system/hardware/fpga/vivado/iob_smart_zynq_sl/iob_system_iob_smart_zynq_sl/iob_system_iob_smart_zynq_sl.py
@@ -247,10 +247,25 @@ def setup(py_params_dict):
                     {"name": "uut_mii_rx_er", "width": "1"},
                     {"name": "uut_mii_crs", "width": "1"},
                     {"name": "uut_mii_col", "width": "1"},
-                    {
-                        "name": "rgmii_mdio_io"
-                    },  # Don't create internal wire 'uut_mii_mdio', because we cant assign bidirectional signals in verilog. Use rgmii_mdio_io signal directly.
+                    # Don't create internal wire 'uut_mii_mdio', because we cant assign bidirectional signals in verilog. Use rgmii_mdio_io signal directly.
+                    {"name": "rgmii_mdio_io"},
                     {"name": "uut_mii_mdc", "width": "1"},
+                ],
+            },
+            {
+                "name": "rgmii_ddr_conversion",
+                "descr": "RGMII DDR conversion",
+                "signals": [
+                    {"name": "rxd_rising_0", "width": 1},
+                    {"name": "rxd_falling_0", "width": 1},
+                    {"name": "rxd_rising_1", "width": 1},
+                    {"name": "rxd_falling_1", "width": 1},
+                    {"name": "rxd_rising_2", "width": 1},
+                    {"name": "rxd_falling_2", "width": 1},
+                    {"name": "rxd_rising_3", "width": 1},
+                    {"name": "rxd_falling_3", "width": 1},
+                    {"name": "rx_dv_rising", "width": 1},
+                    {"name": "rx_dv_falling", "width": 1},
                 ],
             },
         ]
@@ -291,12 +306,16 @@ def setup(py_params_dict):
                     "io_io": "rxclk_buf_io",
                 },
             },
-            {
+            {  # Also instantiated in verilog snippet
                 "core_name": "iob_xilinx_oddr",
                 "instance_name": "txclk_oddr",
                 "connect": {
                     "io_io": "oddr_io",
                 },
+            },
+            {  # Instantiated in verilog snippet
+                "core_name": "iob_xilinx_iddr",
+                "instantiate": False,
             },
         ]
     if params["use_extmem"]:
@@ -481,13 +500,24 @@ def setup(py_params_dict):
     assign uut_mii_rx_clk = eth_clk;
     assign uut_mii_tx_clk = eth_clk;
 
-    // Connect internal MII data/control to external RGMII ports
-    assign uut_mii_rxd = rgmii_rxd_i;
-    assign uut_mii_rx_dv = rgmii_rx_dv_i;
-    assign uut_mii_rx_er = rgmii_rx_er_i;
+    // RGMII RX: DDR capture on all 4 data lines
+    // Same nibble on both edges; IDDR captures both, Q1 (rising) feeds MAC
+    iob_xilinx_iddr iddr_rxd0 (.clk_i(eth_clk), .d_i(rgmii_rxd_i[0]), .q1_o(rxd_rising_0), .q2_o(rxd_falling_0));
+    iob_xilinx_iddr iddr_rxd1 (.clk_i(eth_clk), .d_i(rgmii_rxd_i[1]), .q1_o(rxd_rising_1), .q2_o(rxd_falling_1));
+    iob_xilinx_iddr iddr_rxd2 (.clk_i(eth_clk), .d_i(rgmii_rxd_i[2]), .q1_o(rxd_rising_2), .q2_o(rxd_falling_2));
+    iob_xilinx_iddr iddr_rxd3 (.clk_i(eth_clk), .d_i(rgmii_rxd_i[3]), .q1_o(rxd_rising_3), .q2_o(rxd_falling_3));
+    iob_xilinx_iddr iddr_rxdv (.clk_i(eth_clk), .d_i(rgmii_rx_dv_i), .q1_o(rx_dv_rising), .q2_o(rx_dv_falling));
+    // Feed rising-edge sample (valid MII nibble) to MAC
+    assign uut_mii_rxd = {rxd_rising_3, rxd_rising_2, rxd_rising_1, rxd_rising_0};
+    assign uut_mii_rx_dv = rx_dv_rising;
+    assign uut_mii_rx_er = 1'b0;
 
-    assign rgmii_txd_o = uut_mii_txd;
-    assign rgmii_tx_en_o = uut_mii_tx_en;
+    // RGMII TX: duplicate MII nibble on both DDR edges
+    iob_xilinx_oddr oddr_txd0 (.clk_i(eth_clk), .d1_i(uut_mii_txd[0]), .d2_i(uut_mii_txd[0]), .q_o(rgmii_txd_o[0]));
+    iob_xilinx_oddr oddr_txd1 (.clk_i(eth_clk), .d1_i(uut_mii_txd[1]), .d2_i(uut_mii_txd[1]), .q_o(rgmii_txd_o[1]));
+    iob_xilinx_oddr oddr_txd2 (.clk_i(eth_clk), .d1_i(uut_mii_txd[2]), .d2_i(uut_mii_txd[2]), .q_o(rgmii_txd_o[2]));
+    iob_xilinx_oddr oddr_txd3 (.clk_i(eth_clk), .d1_i(uut_mii_txd[3]), .d2_i(uut_mii_txd[3]), .q_o(rgmii_txd_o[3]));
+    iob_xilinx_oddr oddr_txen (.clk_i(eth_clk), .d1_i(uut_mii_tx_en), .d2_i(uut_mii_tx_en), .q_o(rgmii_tx_en_o));
 
     assign rgmii_mdc_o = uut_mii_mdc;
 

--- a/py2hwsw/lib/iob_system/iob_system_linux/software/tests/iob_eth/iob_eth_host.py
+++ b/py2hwsw/lib/iob_system/iob_system_linux/software/tests/iob_eth/iob_eth_host.py
@@ -146,8 +146,7 @@ def handle_stress_rx(data, sock, soc_addr):
     else:
         delay_ms = 10
 
-    log(f"Stress RX: sending {count} frames of {size} bytes "
-        f"({delay_ms} ms gap)")
+    log(f"Stress RX: sending {count} frames of {size} bytes " f"({delay_ms} ms gap)")
 
     # Build the packet header for echo frames
     pkt = bytearray(HDR_SIZE + size)

--- a/py2hwsw/lib/iob_system/iob_system_linux/software/tests/iob_eth/iob_eth_test.c
+++ b/py2hwsw/lib/iob_system/iob_system_linux/software/tests/iob_eth/iob_eth_test.c
@@ -762,7 +762,7 @@ static uint32_t ether_crc32(const uint8_t *data, size_t len) {
   for (size_t i = 0; i < len; i++) {
     crc ^= data[i];
     for (int b = 0; b < 8; b++)
-      crc = (crc >> 1) ^ (CRC32_POLY & (uint32_t)-(int32_t)(crc & 1));
+      crc = (crc >> 1) ^ (CRC32_POLY & (uint32_t) - (int32_t)(crc & 1));
   }
   return bitrev32(crc);
 }
@@ -787,9 +787,9 @@ static int scan_dmesg_errors(void) {
   FILE *fp;
   char line[512];
   static const char *patterns[] = {
-      "wrong CRC",  "overrun",      "frame too long", "frame too short",
-      "late collision", "retransmit limit", "underrun", "dribble",
-      "carrier sense",
+      "wrong CRC",       "overrun",        "frame too long",
+      "frame too short", "late collision", "retransmit limit",
+      "underrun",        "dribble",        "carrier sense",
   };
   int count = 0;
   size_t npat = sizeof(patterns) / sizeof(patterns[0]);
@@ -799,8 +799,8 @@ static int scan_dmesg_errors(void) {
     return -1;
 
   while (fgets(line, sizeof(line), fp)) {
-    int iface_match = (strstr(line, g_iface) != NULL) ||
-                      (strstr(line, "ethoc") != NULL);
+    int iface_match =
+        (strstr(line, g_iface) != NULL) || (strstr(line, "ethoc") != NULL);
     if (!iface_match)
       continue;
     for (size_t i = 0; i < npat; i++) {
@@ -826,7 +826,8 @@ static int report_dmesg_errors(const char *label, int baseline, int fatal) {
   }
   if (now > baseline) {
     if (fatal) {
-      TEST_FAIL(label, "ethoc reported %d RX/TX error(s) in dmesg (baseline %d)",
+      TEST_FAIL(label,
+                "ethoc reported %d RX/TX error(s) in dmesg (baseline %d)",
                 now - baseline, baseline);
       return 1;
     } else {
@@ -855,9 +856,9 @@ static int dmesg_snapshot(dmesg_snap *snap) {
   FILE *fp;
   char line[512];
   static const char *patterns[] = {
-      "wrong CRC",  "overrun",      "frame too long", "frame too short",
-      "late collision", "retransmit limit", "underrun", "dribble",
-      "carrier sense",
+      "wrong CRC",       "overrun",        "frame too long",
+      "frame too short", "late collision", "retransmit limit",
+      "underrun",        "dribble",        "carrier sense",
   };
   size_t npat = sizeof(patterns) / sizeof(patterns[0]);
   int n = 0;
@@ -867,8 +868,8 @@ static int dmesg_snapshot(dmesg_snap *snap) {
     return -1;
 
   while (n < DMESG_MAX && fgets(line, sizeof(line), fp)) {
-    int iface_match = (strstr(line, g_iface) != NULL) ||
-                      (strstr(line, "ethoc") != NULL);
+    int iface_match =
+        (strstr(line, g_iface) != NULL) || (strstr(line, "ethoc") != NULL);
     if (!iface_match)
       continue;
     for (size_t i = 0; i < npat; i++) {
@@ -2120,13 +2121,13 @@ static int test_ringparam_set(void) {
 
     errno = 0;
     if (set_ethtool_ring(fd, tgt_tx, tgt_rx) < 0) {
-      TEST_FAIL("Ring Set", "set_ringparam(%u,%u) failed: %s", tgt_tx,
-                tgt_rx, strerror(errno));
+      TEST_FAIL("Ring Set", "set_ringparam(%u,%u) failed: %s", tgt_tx, tgt_rx,
+                strerror(errno));
       ok = 0;
     } else if (get_ethtool_ring(fd, &ring) == 0) {
       if (ring.tx_pending != tgt_tx || ring.rx_pending != tgt_rx) {
-        TEST_FAIL("Ring Set", "after set(%u,%u): tx=%u rx=%u", tgt_tx,
-                  tgt_rx, ring.tx_pending, ring.rx_pending);
+        TEST_FAIL("Ring Set", "after set(%u,%u): tx=%u rx=%u", tgt_tx, tgt_rx,
+                  ring.tx_pending, ring.rx_pending);
         ok = 0;
       }
       if (get_ethtool_regs(fd, regs, &count) == 0 &&
@@ -2247,8 +2248,7 @@ static int test_ksettings(void) {
   }
 
   if (get_link_speed_duplex(fd, &speed, &duplex) < 0) {
-    TEST_FAIL("Link Settings", "get_link_settings failed: %s",
-              strerror(errno));
+    TEST_FAIL("Link Settings", "get_link_settings failed: %s", strerror(errno));
     close(fd);
     return -1;
   }
@@ -2651,7 +2651,7 @@ static int test_stress_rx(void) {
   int fd;
   struct net_stats stats_before, stats_after;
   uint16_t count = 200;
-  uint16_t size = g_stress_rx_size; /* default 1468; -b to sweep */
+  uint16_t size = g_stress_rx_size;   /* default 1468; -b to sweep */
   uint16_t delay = g_stress_rx_delay; /* 0 = back-to-back (default) */
   uint8_t payload[6];
   struct cmd_packet pkt;
@@ -2705,7 +2705,8 @@ static int test_stress_rx(void) {
   get_irq_count(&irq_after);
   close(fd);
 
-  /* liveness probe: if small 32B ECHO round-trips now, RX is not fully wedged */
+  /* liveness probe: if small 32B ECHO round-trips now, RX is not fully wedged
+   */
   {
     int pfd = create_test_socket(TEST_ETH_PORT);
     if (pfd >= 0) {
@@ -2732,10 +2733,11 @@ static int test_stress_rx(void) {
 
     if (received < count) {
       if (burst) {
-        TEST_INFO("Stress RX",
-                  "Only received %d/%d frames under line-rate burst (known "
-                  "limitation: 50 MHz SoC cannot sustain 100 Mbps back-to-back)",
-                  received, count);
+        TEST_INFO(
+            "Stress RX",
+            "Only received %d/%d frames under line-rate burst (known "
+            "limitation: 50 MHz SoC cannot sustain 100 Mbps back-to-back)",
+            received, count);
       } else {
         TEST_FAIL("Stress RX", "Only received %d/%d frames under burst",
                   received, count);
@@ -2743,8 +2745,10 @@ static int test_stress_rx(void) {
       }
     }
     if (stats_after.rx_errors > stats_before.rx_errors) {
-      TEST_FAIL("Stress RX", "rx_errors aggregate increased (+%lu); see dmesg "
-               "for sub-counter (overrun/CRC) detail", rxerr);
+      TEST_FAIL("Stress RX",
+                "rx_errors aggregate increased (+%lu); see dmesg "
+                "for sub-counter (overrun/CRC) detail",
+                rxerr);
       ok = 0;
     }
   }
@@ -2990,7 +2994,8 @@ static int test_final_summary(void) {
       if (g_burst_info) {
         TEST_INFO("dmesg",
                   "%d ethoc RX/TX error line(s) in kernel log (line-rate "
-                  "Stress RX burst; known limitation on 50 MHz SoC)", now);
+                  "Stress RX burst; known limitation on 50 MHz SoC)",
+                  now);
       } else {
         TEST_FAIL("dmesg", "%d ethoc RX/TX error line(s) in kernel log", now);
         gate_ok = 0;


### PR DESCRIPTION
## Summary
- Add 4-bit IDDR/ODDR DDR conversion for RGMII Ethernet on Smart Zynq SL FPGA board. Ethernet is now working on this board
- Auto-format iob_eth test files
- Update iob_eth submodule

## Testing
Smart Zynq SL Ethernet communication has been tested working with a network switch between the FPGA board and host machine. Using a network switch will probably work for other boards as well — a direct connection from host machine to FPGA is no longer required.